### PR TITLE
Add instructions for installing KataGo for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,51 @@ To run the all the unit tests, run:
 ```shell
 go test ./...
 ```
+
+## Setting up a Dev Environment
+
+This assumes that you have familiarity with and have installed the following:
+
+1.   [Go](https://golang.org/doc/install)
+2.   [Git](https://git-scm.com/book/en/v2)
+
+### Inital OS Setup
+
+*   **OSX**
+    *   We recommend using [Homebrew](https://brew.sh/) to install any packages you may need.
+
+*   **Linux**: TODO. Send us a PR with instructions!
+
+*   **Windows**: TODO. Send us a PR with instructions!
+
+### Installing KataGo
+
+[KataGo](https://github.com/lightvector/KataGo) works with either
+[CUDA](https://developer.nvidia.com/cuda-zone) or
+[OpenCL](https://www.khronos.org/opencl/). With OpenCL, you can use it without
+needing a GPU machine.
+
+In addition to the built-binaries, KataGo needs 3 configuration files to run:
+
+1.   Model: You can get that from the [KataGo releases](https://github.com/lightvector/KataGo/releases)
+2.   GTP Config: You can get that from the [KataGo releases](https://github.com/lightvector/KataGo/releases)
+3.   Tuning Parameters. This is set via running `katago benchmark -tune`.`
+
+*   **OSX**
+    *   OSX generally comes pre-installed with [OpenCL](https://www.khronos.org/opencl/)
+    *   Run `brew install katago`
+    *   Download the models. Brew comes with a models, which you can get with
+        *   `KATAGO_GTP_CONFIG=$(brew list --verbose katago | grep gtp)`
+        *   `KATAGO_MODEL_PATH= $(brew list --verbose katago | grep .gz | head -1)`
+    *   Tune Katago: `katago benchmark -tune -config $(KATAGO_GTP_CONFIG) -model $(KATAGO_MODEL_PATH)`
+        *   This will output configuration to `$HOME/.katago`
+    *   KataGo should now be operational!
+
+### Using KataGo via UI
+
+*   **OSX/Linux**
+    *   If you want to try it out with a UI, download
+        [Lizzie](https://github.com/featurecat/lizzie) and change the engine
+        command to: `/path/to/katago gtp -config /path/to/config.cfg -model /path/to/model.gz`
+        *   I had better luck editing the `config.txt` file that
+            comes with Lizzie directly, rather than trying to set the engine in the Java UI.


### PR DESCRIPTION
I went through the process of installing KataGo for OSX. Hopefully this
should save future people some time.