### PR TITLE
Remove the use of flags to configure the server, and rely on env vars.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.5
+	github.com/kelseyhightower/envconfig v1.4.0
 	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/grpc-ecosystem/grpc-gateway v1.14.5 h1:aiLxiiVzAXb7wb3lAmubA69IokWOoUNe+E7TdGKh8yw=
 github.com/grpc-ecosystem/grpc-gateway v1.14.5/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/server/config/README.md
+++ b/server/config/README.md
@@ -1,0 +1,5 @@
+# Server Configuration
+
+Configuration for the server comes in two forms:
+
+- Defaults, struct

--- a/server/config/README.md
+++ b/server/config/README.md
@@ -1,5 +1,13 @@
 # Server Configuration
 
-Configuration for the server comes in two forms:
+Configuration is a package for runtime configuration of the Otrego server
+binary, and relies heavily on https://github.com/kelseyhightower/envconfig.
+Runtime configuration for the server comes in two forms:
 
-- Defaults, struct
+- Defaults, which come in the form of struct tags.
+- Overrides, which come in the form of environment variables. For example, to
+  override the Port, the environment variable `OTREGO_PORT=2345` is set.
+
+Note that to set configuration to containers in GCP, you need to specify the
+`--container-env` flag:
+https://cloud.google.com/compute/docs/containers/configuring-options-to-run-containers

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -17,7 +17,8 @@ const (
 	envVarPrefix = "OTREGO"
 )
 
-// Spec is the dynamic configuration spec for the server, which is modified
+// Spec is the dynamic configuration spec for the server, which is modified at
+// runtime via environment variables.
 type Spec struct {
 	// Port for the server, specified with OTREGO_PORT environment variable and
 	// defaulting to 8080 if left unspecified.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,0 +1,35 @@
+// Package contains logic and defaults for the otrego server.
+//
+// Relies on https://github.com/kelseyhightower/envconfig, which is inspired by
+// 12-factor app configuration: https://12factor.net/confi.
+package config
+
+import (
+	"log"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+const (
+	// envVarPrefix is a prefix to all environment variables.  For example, to
+	// specify FOO, you will actually need to specify FOO, unless the struct tag
+	// `envconfig:"OVERRIDE"` is supplied
+	envVarPrefix = "OTREGO"
+)
+
+// Spec is the dynamic configuration spec for the server, which is modified
+type Spec struct {
+	// Port for the server, specified with OTREGO_PORT environment variable and
+	// defaulting to 8080 if left unspecified.
+	Port int `default:"8080"`
+}
+
+// FromEnv creates an a new config Spec from environment configuration.
+func FromEnv() (*Spec, error) {
+	base := &Spec{}
+	err := envconfig.Process(envVarPrefix, base)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return base, nil
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	// envVarPrefix is a prefix to all environment variables.  For example, to
-	// specify FOO, you will actually need to specify FOO, unless the struct tag
-	// `envconfig:"OVERRIDE"` is supplied
+	// specify FOO, you will actually need to specify OTREGO_FOO, unless the
+	// struct tag `envconfig:"OVERRIDE"` is supplied
 	envVarPrefix = "OTREGO"
 )
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,4 +1,4 @@
-// Package contains logic and defaults for the otrego server.
+// Package config contains logic and defaults for the otrego server.
 //
 // Relies on https://github.com/kelseyhightower/envconfig, which is inspired by
 // 12-factor app configuration: https://12factor.net/confi.

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -13,14 +13,9 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	pb "github.com/otrego/clamshell/server/api"
+	"github.com/otrego/clamshell/server/config"
 	"github.com/otrego/clamshell/server/echo"
 )
-
-// Options contains options for running gRPC.
-type Options struct {
-	// Port to listen on.
-	Port int
-}
 
 // Run starts a gRPC server.
 //
@@ -28,7 +23,7 @@ type Options struct {
 //
 // This method of serving both gRPC and gRPC-Gateway is inspired by:
 // https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go
-func Run(opts *Options) {
+func Run(opts *config.Spec) {
 	ctx := context.Background()
 
 	// Listen on addr

--- a/server/main.go
+++ b/server/main.go
@@ -4,20 +4,20 @@ import (
 	"flag"
 
 	glog "github.com/golang/glog"
+	"github.com/otrego/clamshell/server/config"
 	"github.com/otrego/clamshell/server/grpc"
 )
 
-var (
-	port = flag.Int("port", 8080, "The server port")
-)
-
 func main() {
-	flag.Set("alsologtostderr", "true")
+	flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	glog.Info("Starting Clamshell")
 
-	grpc.Run(&grpc.Options{
-		Port: *port,
-	})
+	spec, err := config.FromEnv()
+	if err != nil {
+		glog.Exit(err)
+	}
+
+	grpc.Run(spec)
 }


### PR DESCRIPTION
Only a small modification: this changes the server app to use a more
12-factor-y style configuration system that uses environment variables
instead of flags.

This relies extensively on https://github.com/kelseyhightower/envconfig.

For more about 12-factor apps: https://12factor.net/config