### PR TITLE
Add a treepath implementation

### DIFF
--- a/core/errcheck/errcheck.go
+++ b/core/errcheck/errcheck.go
@@ -1,0 +1,19 @@
+// Package errcheck checks error cases.
+package errcheck
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckCases checks error cases for tests
+func CheckCases(err error, expErrSubstr string) error {
+	if err == nil && expErrSubstr != "" {
+		return fmt.Errorf("got no error but expected error containing %q", expErrSubstr)
+	} else if err != nil && expErrSubstr == "" {
+		return fmt.Errorf("got error %q but expected no error", err.Error())
+	} else if err != nil && !strings.Contains(err.Error(), expErrSubstr) {
+		return fmt.Errorf("Got error %q but expected it to contain %q", err.Error(), expErrSubstr)
+	}
+	return nil
+}

--- a/core/treepath/treepath.go
+++ b/core/treepath/treepath.go
@@ -2,7 +2,7 @@
 //
 // Treepaths are string-encodings of paths through trees.
 //
-// Treepaths come from
+// Treepaths come originially from
 // https://github.com/Kashomon/glift-core/blob/master/src/rules/treepath.js
 package treepath
 
@@ -66,6 +66,10 @@ const (
 )
 
 // Parse parses a treepath from a string to an array of ints.
+//
+// Example:
+// * Parse("2.3")         => [2,3]
+// * Parse("1.2:1.0.2:3") => [1,2,0,2,2,2]
 func Parse(path string) (Treepath, error) {
 	out := Treepath{}
 	curState := variationState

--- a/core/treepath/treepath.go
+++ b/core/treepath/treepath.go
@@ -84,7 +84,6 @@ func Parse(path string) (Treepath, error) {
 	// charactrs.
 	path += "\n"
 
-	//
 	// The rough approach is to have a simple parser modeled as a 2-state DFA.
 	//
 	// VARIATION: means we're parsing a normal variation number. We flush the
@@ -97,7 +96,11 @@ func Parse(path string) (Treepath, error) {
 	//  |      |             |
 	//  V      ^             ^
 	// VARIATION --':'-->  REPEAT
-	//
+	//   |                   V
+	//   EOL <----------------
+	//   |
+	//   V
+	//   End
 	for idx, c := range path {
 		if unicode.IsDigit(c) {
 			buf.WriteRune(c)

--- a/core/treepath/treepath.go
+++ b/core/treepath/treepath.go
@@ -1,0 +1,200 @@
+// Package treepath provides functionality for manipulating treepaths.
+//
+// Treepaths come from
+// https://github.com/Kashomon/glift-core/blob/master/src/rules/treepath.js
+//
+// A treepath is a list of variations that says how to travel through a tree of
+// moves. And has two forms a list version and astring version. First, the
+// list-version:
+//
+//    [0,1,0]
+//
+// Means we will first take the 0th variation, then we will take the 1ist
+// variation, and lastly we will take the 0th variation again. For
+// convenience, the treepath can also be specified by a string, which is where
+// the fun begins. At it's simpliest,
+//
+//    [0,0,0] becomes 0.0.0
+//
+// but there are a couple different string short-hands that make using treepaths
+// a little easier
+//
+//    0.1+    Take the 0th variation, then the 1st variation, then go to the end
+//    0.1:2   Take the 0th variation, then repeat taking the 1st varation twice
+//
+// There are two types of treepaths discussed below -- A *treepath fragment*
+// (which is what we have been describing) and an *initial treepath*.
+//
+// ## Treepath Fragments
+//
+// Treepaths say how to get from position n to position m.  Thus the numbers are
+// always variations except in the case of AxB syntax, where B is a multiplier
+// for a variation.
+//
+// This is how fragment strings are parsed:
+//
+//    0             becomes [0]
+//    1             becomes [1]
+//    53            becomes [53] (the 53rd variation)
+//    2.3           becomes [2,3]
+//    0.0.0.0       becomes [0,0,0]
+//    0:4           becomes [0,0,0,0]
+//    1:4           becomes [1,1,1,1]
+//    1.2:1.0.2:3   becomes [1,2,0,2,2,2]
+//
+// ## Initial tree paths.
+//
+// The initial treepath always treats the first number as a 'move number'
+// instead of a variation. Thus
+//
+//    3.1.0
+//
+// means start at move 3 (always taking the 0th variation path) and then take
+// the path fragment [1,0].
+//
+// Some examples:
+//
+//    0         - Start at the 0th move (the root node)
+//    53        - Start at the 53rd move (taking the 0th variation)
+//    2.3       - Start at the 3rd variation on move 2 (actually move 3)
+//    3         - Start at the 3rd move
+//    2.0       - Start at the 3rd move
+//    0.0.0.0   - Start at the 3rd move
+//    0.0:3     - Start at the 3rd move
+//
+// As with fragments, the init position returned is an array of variation
+// numbers traversed through.  The move number is precisely the length of the
+// array.
+//
+// So, for parsing
+//
+//    0         becomes []
+//    1         becomes [0]
+//    0.1       becomes [1]
+//    53        becomes [0,0,0,...,0] (53 times)
+//    2.3       becomes [0,0,3]
+//    0.0.0.0   becomes [0,0,0]
+//    0.0:3.1:3 becomes [0,0,0,1,1,1]
+//
+// As mentioned before, '+' is a special symbol which means "go to the end via
+// the first variation." This is implemented with a by appending 500 0s to the
+// path array.  This is a hack, but in practice games don't go over 500 moves.
+package treepath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// A treepath represents a variation path through a Game-tree
+type Treepath []int
+
+// ParseInitialPath Parses an initial treepath.
+//
+// The difference between an InitialTreePath and a Treepath-fragment
+// is that the first move is interprented as a move number.
+//
+// Ex:
+//
+// 53 = [0, 0, 0, ... (53 times)]
+func ParseInitialPath(initPos string) (Treepath, error) {
+	ns := make([]rune, 0, 3) // very unlikely that n > 1000
+	idx := 0
+	for _, r := range initPos {
+		if unicode.IsDigit(r) {
+			idx++
+			ns = append(ns, r)
+		} else if r == '.' {
+			idx++
+			break
+		} else {
+			return nil, fmt.Errorf("failed to parse initial path %q, unexpected char at index %d. expected digit or '.'", initPos, idx)
+		}
+	}
+	n, err := strconv.Atoi(string(ns))
+	if err != nil {
+		return nil, err
+	}
+
+	tp := make(Treepath, n, n)
+	for i := 0; i < n; i++ {
+		tp = append(tp, 0)
+	}
+
+	if idx >= len(initPos) {
+		// We have captured the full string.
+		return tp, nil
+	}
+
+	tail, err := ParseFragment(initPos[idx:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse initial path %q: %v", initPos, err)
+	}
+	tp = append(tp, tail...)
+
+	return tp, nil
+}
+
+type parseState int
+
+const (
+	// variation means we are looking for numbers for the variation number. Can
+	// either transition to either separator (flush) or repeat (flush and then
+	// repeat N times
+	variation parseState = iota
+	// repeat means we repeat the previous variation 'n' times.
+	repeat
+)
+
+// ParseFragment parses a treepath fragment.
+func ParseFragment(path string) (Treepath, error) {
+	out := make(Treepath, 0, len(path)/2)
+	curState := variation
+	buf := &strings.Builder{}
+	prevChar := 0
+
+	convertBuffer := func(idx int) (int, error) {
+		if buf.Len() == 0 {
+			return 0, fmt.Errorf("error parsing fragment %q at index %d: separator '.' must be proceeded by digit", path, idx)
+		}
+		n, err := strconv.Atoi(buf.String())
+		if err != nil {
+			return 0, fmt.Errorf("error parsing number in fragment %q at index %d: %v", path, idx, err)
+		}
+		buf = &strings.Builder{}
+		return n, nil
+	}
+
+	for idx, c := range path {
+		if unicode.IsDigit(c) {
+			buf.WriteRune(c)
+		} else if c == '.' {
+			n, err := convertBuffer(idx)
+			if err != nil {
+				return nil, err
+			}
+			if curState == variation {
+				out = append(out, n)
+			} else if curState == repeat {
+				for i := 0; i < n; i++ {
+					out = append(out, prevChar)
+				}
+			}
+		} else if c == ':' {
+			n, err := convertBuffer(idx)
+			if err != nil {
+				return nil, err
+			}
+			if curState == variation {
+				prevChar = n
+			} else if curState == repeat {
+				fmt.Errorf("error parsing fragment %q at index %d: repeat char ':' cannot be followed by another repeat ':'", path, idx)
+			} else {
+				fmt.Errorf("error parsing fragment %q at index %d: unexpectad character %q", path, idx, c)
+			}
+		}
+	}
+	return out, nil
+}

--- a/core/treepath/treepath_test.go
+++ b/core/treepath/treepath_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/otrego/clamshell/core/errcheck"
+	"github.com/otrego/clamshell/core/parser"
 )
 
 func TestParseInitialPath(t *testing.T) {
@@ -192,6 +193,45 @@ func TestParseFragment(t *testing.T) {
 
 			if !cmp.Equal(got, Treepath(tc.exp)) {
 				t.Errorf("ParseInitialPath(%v)=%v, but expected %v", tc.path, got, tc.exp)
+			}
+		})
+	}
+}
+
+func TestApplyPath(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		initPath string
+		game     string
+		expProps map[string][]string
+	}{
+		{
+			desc:     "first move",
+			initPath: "1",
+			game:     "(;GM[1];B[pd]C[foo])",
+			expProps: map[string][]string{
+				"C": []string{"zed"},
+				"B": []string{"pd"},
+			},
+		},
+	}
+	t.Skip("Parsing is currently incorrect:Re-enable test once https://github.com/otrego/clamshell/issues/83 is fixed")
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			g, err := parser.FromString(tc.game).Parse()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			path, err := ParseInitialPath(tc.initPath)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			n := path.Apply(g.Root)
+
+			if !cmp.Equal(n.Properties, tc.expProps) {
+				t.Errorf("path.Apply(root)=%v, expected %v. Diff=%v", n.Properties, tc.expProps, cmp.Diff(n.Properties, tc.expProps))
 			}
 		})
 	}

--- a/core/treepath/treepath_test.go
+++ b/core/treepath/treepath_test.go
@@ -1,0 +1,198 @@
+package treepath
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/otrego/clamshell/core/errcheck"
+)
+
+func TestParseInitialPath(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		path         string
+		exp          []int
+		expErrSubstr string
+	}{
+		{
+			desc: "root move",
+			path: "0",
+			exp:  []int{},
+		},
+		{
+			desc: "first move",
+			path: "1",
+			exp:  []int{0},
+		},
+		{
+			desc: "move 10",
+			path: "10",
+			exp:  []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			desc: "move 2.3",
+			path: "2.3",
+			exp:  []int{0, 0, 3},
+		},
+		{
+			desc: "move 3",
+			path: "3",
+			exp:  []int{0, 0, 0},
+		},
+		{
+			desc: "move 2.0 = move 3",
+			path: "2.0",
+			exp:  []int{0, 0, 0},
+		},
+		{
+			desc: "move 0.0.0.0 = move 3",
+			path: "0.0.0.0",
+			exp:  []int{0, 0, 0},
+		},
+		{
+			desc: "move 0.0:3 = move 3",
+			path: "0.0:3",
+			exp:  []int{0, 0, 0},
+		},
+		// Error cases
+		{
+			desc:         "move 0:2 is invalid - no repeat on initial pos",
+			path:         "0:2",
+			expErrSubstr: "unexpected char",
+		},
+		{
+			desc:         "move a:2 is invalid - not a number",
+			path:         "a:2",
+			expErrSubstr: "unexpected char",
+		},
+		{
+			desc:         "move -1:2 is invalid - negatives are not allowed",
+			path:         "-1:2",
+			expErrSubstr: "unexpected char",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := ParseInitialPath(tc.path)
+
+			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
+			if cerr != nil {
+				t.Error(cerr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			if !cmp.Equal(got, Treepath(tc.exp)) {
+				t.Errorf("ParseInitialPath(%v)=%v, but expected %v", tc.path, got, tc.exp)
+			}
+		})
+	}
+}
+
+func TestParseFragment(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		path         string
+		exp          []int
+		expErrSubstr string
+	}{
+		{
+			desc: "0th varation",
+			path: "0",
+			exp:  []int{0},
+		},
+		{
+			desc: "first move",
+			path: "1",
+			exp:  []int{1},
+		},
+		{
+			desc: "variation 10",
+			path: "10",
+			exp:  []int{10},
+		},
+		{
+			desc: "move 2.3",
+			path: "2.3",
+			exp:  []int{2, 3},
+		},
+		{
+			desc: "varitaion 3",
+			path: "3",
+			exp:  []int{3},
+		},
+		{
+			desc: "move 2.0",
+			path: "2.0",
+			exp:  []int{2, 0},
+		},
+		{
+			desc: "move 0.0.0.0 = 4 moves",
+			path: "0.0.0.0",
+			exp:  []int{0, 0, 0, 0},
+		},
+		{
+			desc: "move 0.0:3 = 4 moves",
+			path: "0.0:3",
+			exp:  []int{0, 0, 0, 0},
+		},
+		{
+			desc: "move 0:4 = 4 moves",
+			path: "0:4",
+			exp:  []int{0, 0, 0, 0},
+		},
+		{
+			desc: "move 0:4 = 4 moves @ var 1",
+			path: "1:4",
+			exp:  []int{1, 1, 1, 1},
+		},
+		{
+			desc: "complicated pattern",
+			path: "1.2:1.0.3:3",
+			exp:  []int{1, 2, 0, 3, 3, 3},
+		},
+		// Error cases
+		{
+			desc:         "move a:2 is invalid - not a number",
+			path:         "a:2",
+			expErrSubstr: "unexpected char",
+		},
+		{
+			desc:         "move -1:2 is invalid - negatives are not allowed",
+			path:         "-1:2",
+			expErrSubstr: "unexpected char",
+		},
+		{
+			desc:         "move 1::2 is invalid - no repeat separators",
+			path:         "1::2",
+			expErrSubstr: "separator",
+		},
+		{
+			desc:         "move 1..2 is invalid - no repeat separators",
+			path:         "1..2",
+			expErrSubstr: "separator",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := ParseFragment(tc.path)
+
+			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
+			if cerr != nil {
+				t.Error(cerr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			if !cmp.Equal(got, Treepath(tc.exp)) {
+				t.Errorf("ParseInitialPath(%v)=%v, but expected %v", tc.path, got, tc.exp)
+			}
+		})
+	}
+}

--- a/core/treepath/treepath_test.go
+++ b/core/treepath/treepath_test.go
@@ -8,92 +8,7 @@ import (
 	"github.com/otrego/clamshell/core/parser"
 )
 
-func TestParseInitialPath(t *testing.T) {
-	testCases := []struct {
-		desc         string
-		path         string
-		exp          []int
-		expErrSubstr string
-	}{
-		{
-			desc: "root move",
-			path: "0",
-			exp:  []int{},
-		},
-		{
-			desc: "first move",
-			path: "1",
-			exp:  []int{0},
-		},
-		{
-			desc: "move 10",
-			path: "10",
-			exp:  []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		{
-			desc: "move 2.3",
-			path: "2.3",
-			exp:  []int{0, 0, 3},
-		},
-		{
-			desc: "move 3",
-			path: "3",
-			exp:  []int{0, 0, 0},
-		},
-		{
-			desc: "move 2.0 = move 3",
-			path: "2.0",
-			exp:  []int{0, 0, 0},
-		},
-		{
-			desc: "move 0.0.0.0 = move 3",
-			path: "0.0.0.0",
-			exp:  []int{0, 0, 0},
-		},
-		{
-			desc: "move 0.0:3 = move 3",
-			path: "0.0:3",
-			exp:  []int{0, 0, 0},
-		},
-		// Error cases
-		{
-			desc:         "move 0:2 is invalid - no repeat on initial pos",
-			path:         "0:2",
-			expErrSubstr: "unexpected char",
-		},
-		{
-			desc:         "move a:2 is invalid - not a number",
-			path:         "a:2",
-			expErrSubstr: "unexpected char",
-		},
-		{
-			desc:         "move -1:2 is invalid - negatives are not allowed",
-			path:         "-1:2",
-			expErrSubstr: "unexpected char",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			got, err := ParseInitialPath(tc.path)
-
-			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
-			if cerr != nil {
-				t.Error(cerr)
-				return
-			}
-			if err != nil {
-				return
-			}
-
-			if !cmp.Equal(got, Treepath(tc.exp)) {
-				t.Errorf("ParseInitialPath(%v)=%v, but expected %v", tc.path, got, tc.exp)
-			}
-		})
-	}
-}
-
-func TestParseFragment(t *testing.T) {
+func TestParse(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		path         string
@@ -180,7 +95,7 @@ func TestParseFragment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := ParseFragment(tc.path)
+			got, err := Parse(tc.path)
 
 			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
 			if cerr != nil {
@@ -192,7 +107,7 @@ func TestParseFragment(t *testing.T) {
 			}
 
 			if !cmp.Equal(got, Treepath(tc.exp)) {
-				t.Errorf("ParseInitialPath(%v)=%v, but expected %v", tc.path, got, tc.exp)
+				t.Errorf("Parse(%v)=%v, but expected %v", tc.path, got, tc.exp)
 			}
 		})
 	}
@@ -207,7 +122,7 @@ func TestApplyPath(t *testing.T) {
 	}{
 		{
 			desc:     "first move",
-			initPath: "1",
+			initPath: "0.0",
 			game:     "(;GM[1];B[pd]C[foo])",
 			expProps: map[string][]string{
 				"C": []string{"zed"},
@@ -223,7 +138,7 @@ func TestApplyPath(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			path, err := ParseInitialPath(tc.initPath)
+			path, err := Parse(tc.initPath)
 			if err != nil {
 				t.Error(err)
 				return

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.0
+	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/grpc-gateway v1.14.5
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This adds a clean-slate implementation of the treepath from gliftgo: https://github.com/Kashomon/glift-core/blob/master/src/rules/treepath.js

Treepath is one of the more useful things I created for Glift, so makes perfect sense to port-over.

Note: I drop the plus syntax (4+ or 0.2+) because it was never really used. The 2:3 was more versatile and useful, ultimately.