### PR TITLE
Updated point.go and point_test.go

### DIFF
--- a/core/point/point.go
+++ b/core/point/point.go
@@ -1,6 +1,10 @@
 // Package point is a basic package for points.
 package point
 
+import (
+	"fmt"
+)
+
 // Point is a basic point. Although simple, the member variables are kept
 // private to ensure that Point remains immutable.
 type Point struct {
@@ -8,9 +12,9 @@ type Point struct {
 	y int64
 }
 
-// PointToSgfMap is a translation reference between int64 Point
+// pointToSgfMap is a translation reference between int64 Point
 // and string SGF-Point (rune) values
-var PointToSgfMap = map[int64]rune{
+var pointToSgfMap = map[int64]rune{
 	0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g',
 	7: 'h', 8: 'i', 9: 'j', 10: 'k', 11: 'l', 12: 'm', 13: 'n',
 	14: 'o', 15: 'p', 16: 'q', 17: 'r', 18: 's', 19: 't', 20: 'u',
@@ -21,9 +25,9 @@ var PointToSgfMap = map[int64]rune{
 	49: 'X', 50: 'Y', 51: 'Z',
 }
 
-// SgfToPointMap is a translation reference between string SGF-Point
+// sgfToPointMap is a translation reference between string SGF-Point
 // (rune) values and int64 Point values
-var SgfToPointMap = map[rune]int64{
+var sgfToPointMap = map[rune]int64{
 	'a': 0, 'b': 1, 'c': 2, 'd': 3, 'e': 4, 'f': 5, 'g': 6, 'h': 7,
 	'i': 8, 'j': 9, 'k': 10, 'l': 11, 'm': 12, 'n': 13, 'o': 14,
 	'p': 15, 'q': 16, 'r': 17, 's': 18, 't': 19, 'u': 20, 'v': 21,
@@ -51,30 +55,41 @@ func (pt *Point) Y() int64 { return pt.y }
 // ToSGF converts a pointer-type (immutable) *Point
 // to an SGF Point (two letter string).
 // The returned value is 0-indexed.
-func (pt *Point) ToSGF() string {
-	sgfOut := ""
+func (pt *Point) ToSGF() (string, error) {
+	var sgfOut string
+	var err01 = fmt.Errorf("")
 	if (pt.X() <= 51) && (pt.Y() <= 51) {
-		sgfX := string(PointToSgfMap[pt.X()])
-		sgfY := string(PointToSgfMap[pt.Y()])
+		sgfX := string(pointToSgfMap[pt.X()])
+		sgfY := string(pointToSgfMap[pt.Y()])
 		sgfOut = sgfX + sgfY
+		err01 = nil
 	} else {
-		sgfOut = "--"
+		sgfOut = ""
+		err01 = fmt.Errorf("*Point int64 x and y value entries must" +
+			" be greater than or equal to 0, " +
+			"and less than or equal to 51. ")
+		// err01 = errors.New("*Point x and y value entries must be" +
+		// 	" greater than or equal to 0, and less than or equal to 51")
 	}
-	return sgfOut
+	return sgfOut, err01
 }
 
 // NewFromSGF converts an SGF point (two letter string)
 // to a pointer-type (immutable) *Point.
-func NewFromSGF(sgfPt string) *Point {
+func NewFromSGF(sgfPt string) (*Point, error) {
 	var intX int64
 	var intY int64
+	var err02 = fmt.Errorf("")
 	if (sgfPt != "") && (sgfPt != "--") && (len(sgfPt) == 2) {
-		intX = SgfToPointMap[rune(sgfPt[0])]
-		intY = SgfToPointMap[rune(sgfPt[1])]
+		intX = sgfToPointMap[rune(sgfPt[0])]
+		intY = sgfToPointMap[rune(sgfPt[1])]
+		err02 = nil
 	} else {
 		intX = 99
 		intY = 99
+		err02 = fmt.Errorf("SGF string x and y value entries must non" +
+			"-empty and of length 2 (runes/chars). ")
 	}
-	return New(intX, intY)
+	return New(intX, intY), err02
 
 }

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -37,30 +37,33 @@ func (pt *Point) Y() int64 { return pt.y }
 // ToSGF converts a pointer-type (immutable) *Point
 // to an SGF Point (two letter string). The returned value is 0-indexed.
 func (pt *Point) ToSGF() string {
+	sgfOut := ""
 	if (pt != nil) && (pt.X() <= 51) && (pt.Y() <= 51) {
 		sgfX := string(PointSGFSlce[pt.X()])
 		sgfY := string(PointSGFSlce[pt.Y()])
-		return sgfX + sgfY
+		sgfOut = sgfX + sgfY
 	} else {
 		panic("Error: *Point entries must not be nil for either" +
 			" x y entries and have 0 <= x, y <= 51 values. ")
 	}
+	return sgfOut
 }
 
 // NewFromSGF converts an SGF point (
 // two letter string, 0-indexed) to a pointer-type (immutable) *Point.
 func NewFromSGF(sgfPt string) *Point {
+	var xIndx int
+	var yIndx int
 	if (sgfPt != "") && (len(sgfPt) == 2) {
-		xIndx := bytes.Index(PointSGFSlce, []byte(string(sgfPt[0])))
-		yIndx := bytes.Index(PointSGFSlce, []byte(string(sgfPt[1])))
-
+		xIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[0])))
+		yIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[1])))
 		// x := int64(sgfPt[0]) - aValue
 		// y := int64(sgfPt[1]) - aValue
-		return New(int64(xIndx), int64(yIndx))
 	} else {
 		panic("Error: SGF string entries must not be empty and must" +
 			" be of length = 2 byte/byte.  ")
 		// return New(99, 99)
 	}
+	return New(int64(xIndx), int64(yIndx))
 
 }

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -1,10 +1,6 @@
 // Package point is a basic package for points.
 package point
 
-import (
-	"bytes"
-)
-
 // Point is a basic point. Although simple, the member variables are kept
 // private to ensure that Point remains immutable.
 type Point struct {
@@ -12,13 +8,32 @@ type Point struct {
 	y int64
 }
 
-// PointSGFSlce is a slice/Array translation reference between integer
-// -Point (index position) and string SGF-Point (byte/char) values
-var PointSGFSlce = []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
-	'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
-	'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-	'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
-	'V', 'W', 'X', 'Y', 'Z', 'x', 'y', 'z'}
+// PointToSgfMap is a translation reference between int64 Point
+// and string SGF-Point (rune) values
+
+var PointToSgfMap = map[int64]rune{
+	0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g',
+	7: 'h', 8: 'i', 9: 'j', 10: 'k', 11: 'l', 12: 'm', 13: 'n',
+	14: 'o', 15: 'p', 16: 'q', 17: 'r', 18: 's', 19: 't', 20: 'u',
+	21: 'v', 22: 'w', 23: 'x', 24: 'y', 25: 'z', 26: 'A', 27: 'B',
+	28: 'C', 29: 'D', 30: 'E', 31: 'F', 32: 'G', 33: 'H', 34: 'I',
+	35: 'J', 36: 'K', 37: 'L', 38: 'M', 39: 'N', 40: 'O', 41: 'P',
+	42: 'Q', 43: 'R', 44: 'S', 45: 'T', 46: 'U', 47: 'V', 48: 'W',
+	49: 'X', 50: 'Y', 51: 'Z',
+}
+
+// SgfToPointMap is a translation reference between string SGF-Point
+// (rune) values and int64 Point values
+var SgfToPointMap = map[rune]int64{
+	'a': 0, 'b': 1, 'c': 2, 'd': 3, 'e': 4, 'f': 5, 'g': 6, 'h': 7,
+	'i': 8, 'j': 9, 'k': 10, 'l': 11, 'm': 12, 'n': 13, 'o': 14,
+	'p': 15, 'q': 16, 'r': 17, 's': 18, 't': 19, 'u': 20, 'v': 21,
+	'w': 22, 'x': 23, 'y': 24, 'z': 25, 'A': 26, 'B': 27, 'C': 28,
+	'D': 29, 'E': 30, 'F': 31, 'G': 32, 'H': 33, 'I': 34, 'J': 35,
+	'K': 36, 'L': 37, 'M': 38, 'N': 39, 'O': 40, 'P': 41, 'Q': 42,
+	'R': 43, 'S': 44, 'T': 45, 'U': 46, 'V': 47, 'W': 48, 'X': 49,
+	'Y': 50, 'Z': 51,
+}
 
 // New creates a new immutable Point.
 func New(x, y int64) *Point {
@@ -35,32 +50,32 @@ func (pt *Point) X() int64 { return pt.x }
 func (pt *Point) Y() int64 { return pt.y }
 
 // ToSGF converts a pointer-type (immutable) *Point
-// to an SGF Point (two letter string). The returned value is 0-indexed.
+// to an SGF Point (two letter string).
+// The returned value is 0-indexed.
 func (pt *Point) ToSGF() string {
 	sgfOut := ""
-	if (pt != nil) && (pt.X() <= 51) && (pt.Y() <= 51) {
-		sgfX := string(PointSGFSlce[pt.X()])
-		sgfY := string(PointSGFSlce[pt.Y()])
+	if (pt.X() <= 51) && (pt.Y() <= 51) {
+		sgfX := string(PointToSgfMap[pt.X()])
+		sgfY := string(PointToSgfMap[pt.Y()])
 		sgfOut = sgfX + sgfY
 	} else {
-		panic("Error: *Point entries must not be nil for either" +
-			" x y entries and have 0 <= x, y <= 51 values. ")
+		sgfOut = "--"
 	}
 	return sgfOut
 }
 
-// NewFromSGF converts an SGF point (
-// two letter string, 0-indexed) to a pointer-type (immutable) *Point.
+// NewFromSGF converts an SGF point (two letter string)
+// to a pointer-type (immutable) *Point.
 func NewFromSGF(sgfPt string) *Point {
-	var xIndx int
-	var yIndx int
-	if (sgfPt != "") && (len(sgfPt) == 2) {
-		xIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[0])))
-		yIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[1])))
+	var intX int64
+	var intY int64
+	if (sgfPt != "") && (sgfPt != "--") && (len(sgfPt) == 2) {
+		intX = SgfToPointMap[rune(sgfPt[0])]
+		intY = SgfToPointMap[rune(sgfPt[1])]
 	} else {
-		panic("Error: SGF string entries must not be empty and must" +
-			" be of length = 2 byte/byte.  ")
+		intX = 99
+		intY = 99
 	}
-	return New(int64(xIndx), int64(yIndx))
+	return New(intX, intY)
 
 }

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -1,12 +1,24 @@
 // Package point is a basic package for points.
 package point
 
+import (
+	"bytes"
+)
+
 // Point is a basic point. Although simple, the member variables are kept
 // private to ensure that Point remains immutable.
 type Point struct {
 	x int64
 	y int64
 }
+
+// PointSGFSlce is a slice/Array translation reference between integer
+// -Point (index position) and string SGF-Point (byte/char) values
+var PointSGFSlce = []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+	'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
+	'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+	'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
+	'V', 'W', 'X', 'Y', 'Z', 'x', 'y', 'z'}
 
 // New creates a new immutable Point.
 func New(x, y int64) *Point {
@@ -21,3 +33,34 @@ func (p *Point) X() int64 { return p.x }
 
 // Y returns the y-value.
 func (p *Point) Y() int64 { return p.y }
+
+// ToSGF() converts a pointer-type (immutable) *Point
+// to an SGF Point (two letter string). The returned value is 0-indexed.
+func (pt *Point) ToSGF() string {
+	if (pt != nil) && (pt.X() <= 51) && (pt.Y() <= 51) {
+		sgfX := string(PointSGFSlce[pt.X()])
+		sgfY := string(PointSGFSlce[pt.Y()])
+		return sgfX + sgfY
+	} else {
+		panic("Error: *Point entries must not be nil for either" +
+			" x y entries and have 0 <= x, y <= 51 values. ")
+	}
+}
+
+// NewFromSGF converts an SGF point (
+// two letter string, 0-indexed) to a pointer-type (immutable) *Point.
+func NewFromSGF(sgfPt string) *Point {
+	if (sgfPt != "") && (len(sgfPt) == 2) {
+		xIndx := bytes.Index(PointSGFSlce, []byte(string(sgfPt[0])))
+		yIndx := bytes.Index(PointSGFSlce, []byte(string(sgfPt[1])))
+
+		// x := int64(sgfPt[0]) - aValue
+		// y := int64(sgfPt[1]) - aValue
+		return New(int64(xIndx), int64(yIndx))
+	} else {
+		panic("Error: SGF string entries must not be empty and must" +
+			" be of length = 2 byte/byte.  ")
+		// return New(99, 99)
+	}
+
+}

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -57,12 +57,9 @@ func NewFromSGF(sgfPt string) *Point {
 	if (sgfPt != "") && (len(sgfPt) == 2) {
 		xIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[0])))
 		yIndx = bytes.Index(PointSGFSlce, []byte(string(sgfPt[1])))
-		// x := int64(sgfPt[0]) - aValue
-		// y := int64(sgfPt[1]) - aValue
 	} else {
 		panic("Error: SGF string entries must not be empty and must" +
 			" be of length = 2 byte/byte.  ")
-		// return New(99, 99)
 	}
 	return New(int64(xIndx), int64(yIndx))
 

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -34,7 +34,7 @@ func (p *Point) X() int64 { return p.x }
 // Y returns the y-value.
 func (p *Point) Y() int64 { return p.y }
 
-// ToSGF() converts a pointer-type (immutable) *Point
+// ToSGF converts a pointer-type (immutable) *Point
 // to an SGF Point (two letter string). The returned value is 0-indexed.
 func (pt *Point) ToSGF() string {
 	if (pt != nil) && (pt.X() <= 51) && (pt.Y() <= 51) {

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -29,10 +29,10 @@ func New(x, y int64) *Point {
 }
 
 // X returns the x-value.
-func (p *Point) X() int64 { return p.x }
+func (pt *Point) X() int64 { return pt.x }
 
 // Y returns the y-value.
-func (p *Point) Y() int64 { return p.y }
+func (pt *Point) Y() int64 { return pt.y }
 
 // ToSGF converts a pointer-type (immutable) *Point
 // to an SGF Point (two letter string). The returned value is 0-indexed.

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -10,7 +10,6 @@ type Point struct {
 
 // PointToSgfMap is a translation reference between int64 Point
 // and string SGF-Point (rune) values
-
 var PointToSgfMap = map[int64]rune{
 	0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g',
 	7: 'h', 8: 'i', 9: 'j', 10: 'k', 11: 'l', 12: 'm', 13: 'n',

--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -14,21 +14,16 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestPointSGFTranslation(t *testing.T) {
-	type Point struct {
-		x int64
-		y int64
-	}
-
+func TestPointToSGFTranslate(t *testing.T) {
 	// First test translation from integer-point to SGF-string-point
 	testToSGFCases := []struct {
 		desc string
-		in   Point
+		in   *Point
 		want string
 	}{
 		{
 			desc: "Point => SGF",
-			in: Point{
+			in: &Point{
 				x: 8,
 				y: 16,
 			},
@@ -36,7 +31,7 @@ func TestPointSGFTranslation(t *testing.T) {
 		},
 		{
 			desc: "Point => SGF",
-			in: Point{
+			in: &Point{
 				x: 12,
 				y: 5,
 			},
@@ -44,7 +39,7 @@ func TestPointSGFTranslation(t *testing.T) {
 		},
 		{
 			desc: "Point => SGF",
-			in: Point{
+			in: &Point{
 				x: 33,
 				y: 8,
 			},
@@ -52,7 +47,7 @@ func TestPointSGFTranslation(t *testing.T) {
 		},
 		{
 			desc: "Point => SGF",
-			in: Point{
+			in: &Point{
 				x: 40,
 				y: 51,
 			},
@@ -61,16 +56,17 @@ func TestPointSGFTranslation(t *testing.T) {
 	}
 
 	for _, tc := range testToSGFCases {
-		t.Run(tc.desc, func(t01 *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			toSGFOut := New(tc.in.x, tc.in.y).ToSGF()
-			if t01 == nil || toSGFOut != tc.want {
-				t01.Errorf("%q.ToSGF() = %q, but wanted %q", tc.in,
+			if toSGFOut != tc.want {
+				t.Errorf("%q.ToSGF() = %q, but wanted %q", tc.in,
 					toSGFOut, tc.want)
 			}
 		})
 	}
+}
 
-	// Second test translation from SGF-string-point to integer-point
+func TestSGFToPointTranslate(t *testing.T) {
 	testToPointCases := []struct {
 		desc string
 		in   string
@@ -111,19 +107,20 @@ func TestPointSGFTranslation(t *testing.T) {
 	}
 
 	for _, tc := range testToPointCases {
-		t.Run(tc.desc, func(t01 *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			toPointOut := NewFromSGF(tc.in)
 			// include the point.go *Point type X Y getters below
 			pointX := toPointOut.X()
 			pointY := toPointOut.Y()
-			if t01 == nil || pointX != tc.want.x {
-				t01.Errorf("%q.toPointOut.x = %q, but wanted %q", tc.in,
+			if pointX != tc.want.x {
+				t.Errorf("%q.toPointOut.x = %q, but wanted %q", tc.in,
 					pointX, tc.want.x)
 			}
-			if t01 == nil || pointY != tc.want.y {
-				t01.Errorf("%q.toPointOut.y = %q, but wanted %q", tc.in,
+			if pointY != tc.want.y {
+				t.Errorf("%q.toPointOut.y = %q, but wanted %q", tc.in,
 					pointY, tc.want.y)
 			}
 		})
 	}
+
 }

--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -113,7 +113,7 @@ func TestPointSGFTranslation(t *testing.T) {
 	for _, tc := range testToPointCases {
 		t.Run(tc.desc, func(t01 *testing.T) {
 			toPointOut := NewFromSGF(tc.in)
-			// include the point.go *Point type X() Y() getters below
+			// include the point.go *Point type X Y getters below
 			pointX := toPointOut.X()
 			pointY := toPointOut.Y()
 			if t01 == nil || pointX != tc.want.x {

--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -57,7 +57,7 @@ func TestPointToSGFTranslate(t *testing.T) {
 
 	for _, tc := range testToSGFCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			toSGFOut := New(tc.in.x, tc.in.y).ToSGF()
+			toSGFOut, _ := New(tc.in.x, tc.in.y).ToSGF()
 			if toSGFOut != tc.want {
 				t.Errorf("%q.ToSGF() = %q, but wanted %q", tc.in,
 					toSGFOut, tc.want)
@@ -108,7 +108,7 @@ func TestSGFToPointTranslate(t *testing.T) {
 
 	for _, tc := range testToPointCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			toPointOut := NewFromSGF(tc.in)
+			toPointOut, _ := NewFromSGF(tc.in)
 			// include the point.go *Point type X Y getters below
 			pointX := toPointOut.X()
 			pointY := toPointOut.Y()

--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -13,3 +13,117 @@ func TestCreate(t *testing.T) {
 		t.Errorf("p.Y()=%v, expected %v", gotY, 2)
 	}
 }
+
+func TestPointSGFTranslation(t *testing.T) {
+	type Point struct {
+		x int64
+		y int64
+	}
+
+	// First test translation from integer-point to SGF-string-point
+	testToSGFCases := []struct {
+		desc string
+		in   Point
+		want string
+	}{
+		{
+			desc: "Point => SGF",
+			in: Point{
+				x: 8,
+				y: 16,
+			},
+			want: "iq",
+		},
+		{
+			desc: "Point => SGF",
+			in: Point{
+				x: 12,
+				y: 5,
+			},
+			want: "mf",
+		},
+		{
+			desc: "Point => SGF",
+			in: Point{
+				x: 33,
+				y: 8,
+			},
+			want: "Hi",
+		},
+		{
+			desc: "Point => SGF",
+			in: Point{
+				x: 40,
+				y: 51,
+			},
+			want: "OZ",
+		},
+	}
+
+	for _, tc := range testToSGFCases {
+		t.Run(tc.desc, func(t01 *testing.T) {
+			toSGFOut := New(tc.in.x, tc.in.y).ToSGF()
+			if t01 == nil || toSGFOut != tc.want {
+				t01.Errorf("%q.ToSGF() = %q, but wanted %q", tc.in,
+					toSGFOut, tc.want)
+			}
+		})
+	}
+
+	// Second test translation from SGF-string-point to integer-point
+	testToPointCases := []struct {
+		desc string
+		in   string
+		want *Point
+	}{
+		{
+			desc: "SGF => Point",
+			in:   "iq",
+			want: &Point{
+				x: 8,
+				y: 16,
+			},
+		},
+		{
+			desc: "SGF => Point",
+			in:   "mf",
+			want: &Point{
+				x: 12,
+				y: 5,
+			},
+		},
+		{
+			desc: "SGF => Point",
+			in:   "Hi",
+			want: &Point{
+				x: 33,
+				y: 8,
+			},
+		},
+		{
+			desc: "SGF => Point",
+			in:   "OZ",
+			want: &Point{
+				x: 40,
+				y: 51,
+			},
+		},
+	}
+
+	for _, tc := range testToPointCases {
+		t.Run(tc.desc, func(t01 *testing.T) {
+			toPointOut := NewFromSGF(tc.in)
+			// include the point.go *Point type X() Y() getters below
+			pointX := toPointOut.X()
+			pointY := toPointOut.Y()
+			if t01 == nil || pointX != tc.want.x {
+				t01.Errorf("%q.toPointOut.x = %q, but wanted %q", tc.in,
+					pointX, tc.want.x)
+			}
+			if t01 == nil || pointY != tc.want.y {
+				t01.Errorf("%q.toPointOut.y = %q, but wanted %q", tc.in,
+					pointY, tc.want.y)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updated point.go and point_test.go. Included test tables, some basic translation function error handling and changed the translation method from ASCII to a slice of chars/bytes a to z, lower and upper case. 