### PR TITLE
sgf.serialize refactor

### DIFF
--- a/core/sgf/parser.go
+++ b/core/sgf/parser.go
@@ -395,38 +395,3 @@ func postProcessProperties(n *game.Node, prop string, propData []string) error {
 
 	return nil
 }
-
-// Serialize converts a Game into SGF format.
-// Calls serializeHelper.
-func Serialize(g *game.Game) string {
-	return fmt.Sprintf("(%s)", serializeHelper(g.Root))
-}
-
-// serializHelper is a recursive DFS searching all
-// descendant nodes of n.
-func serializeHelper(n *game.Node) string {
-	var sb strings.Builder
-	sb.WriteString(writeNode(n))
-	for _, child := range n.Children {
-		if len(n.Children) > 1 {
-			sb.WriteString(fmt.Sprintf("(%s)", serializeHelper(child)))
-		} else {
-			sb.WriteString(serializeHelper(child))
-		}
-	}
-	return sb.String()
-}
-
-// writeNode writes a node in SGF format
-func writeNode(n *game.Node) string {
-	var sb strings.Builder
-
-	sb.WriteString(";")
-	for key := range n.Properties {
-		sb.WriteString(key)
-		for _, value := range n.Properties[key] {
-			sb.WriteString(fmt.Sprintf("[%s]", value))
-		}
-	}
-	return sb.String()
-}

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -1,9 +1,7 @@
 package sgf_test
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -322,107 +320,6 @@ func TestPropertyPostProcessing(t *testing.T) {
 			got := tc.getter(tp.Apply(g.Root))
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("from node-getter and path %q, got %v, but wanted %v", tc.path, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestSerialize(t *testing.T) {
-	testCases := []struct {
-		desc string
-		sgf  string
-	}{
-		{
-			desc: "black move",
-			sgf:  "(;GM[1];B[ab])",
-		},
-		{
-			desc: "white move",
-			sgf:  "(;GM[1];W[ab])",
-		},
-		{
-			desc: "black & white placements",
-			sgf:  "(;GM[1];AB[ab][ac]AW[bb][bc])",
-		},
-		{
-			desc: "complex problem",
-			sgf: `
-(;GM[1]FF[4]CA[UTF-8]AP[Glift]ST[2]
-RU[Japanese]SZ[19]KM[0.00]
-C[Black to play. There aren't many options
-to choose from, but you might be surprised at the answer!]
-PW[White]PB[Black]AW[pa][qa][nb][ob][qb][oc][pc][md][pd][ne][oe]
-AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
-(;B[mc]
-	;W[nc]C[White lives.])
-(;B[ma]
-	(;W[oa]
-		;B[nc]
-		;W[nd]
-		;B[mc]C[White dies.]GB[1])
-	(;W[mc]
-		(;B[oa]
-		;W[nd]
-		;B[pb]C[White lives])
-		(;B[nd]
-			;W[nc]
-			;B[oa]C[White dies.]GB[1]))
-	(;W[nd]
-		;B[mc]
-		;W[oa]
-		;B[nc]C[White dies.]GB[1]))
-(;B[nc]
-	;W[mc]C[White lives])
-(;B[]C[A default consideration]
-	;W[mc]C[White lives easily]))`,
-		},
-		{
-			desc: "mega mark test",
-			sgf: `
-(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]
-RU[Japanese]SZ[19]KM[0.00]
-PW[White]PB[Black]
-AW[na][oa][pa][qa][ra][sa][ka][la][ma][ja]
-AB[nb][ob][pb][qb][rb][sb][kb][lb][mb][jb]
-LB[pa:A][ob:2][pb:B][pc:C][pd:D]
-[oa:1][oc:3][ne:9][oe:8][pe:7][qe:6][re:5][se:4]
-[nf:15][of:14][pf:13][qf:11][rf:12][sf:10]
-[ng:22][og:44][pg:100]
-[ka:a][kb:b][kc:c][kd:d][ke:e][kf:f][kg:g]
-[ma:\u4e00][mb:\u4e8c][mc:\u4e09][md:\u56db][me:\u4e94]
-[la:\u516d][lb:\u4e03][lc:\u516b][ld:\u4e5d][le:\u5341]
-MA[na][nb][nc]
-CR[qa][qb][qc]
-TR[sa][sb][sc]
-SQ[ra][rb][rc]
-)`,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			//Create game
-			g, err := sgf.Parse(tc.sgf)
-			if err != nil {
-				t.Error(err)
-				return
-			}
-
-			//convert original game back to sgf, then back to new game
-			got, err := sgf.Parse(sgf.Serialize(g))
-
-			//check if both games are identical
-			var sbWant strings.Builder
-			var sbGot strings.Builder
-			g.Root.Traverse(func(n *game.Node) {
-				sbWant.WriteString(fmt.Sprintf("%v", n.Properties))
-			})
-
-			got.Root.Traverse(func(n *game.Node) {
-				sbGot.WriteString(fmt.Sprintf("%v", n.Properties))
-			})
-
-			if sbWant.String() != sbGot.String() {
-				t.Errorf("want:\n%s\ngot%s", sbWant.String(), sbGot.String())
 			}
 		})
 	}

--- a/core/sgf/serialize.go
+++ b/core/sgf/serialize.go
@@ -1,0 +1,43 @@
+package sgf
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/otrego/clamshell/core/game"
+)
+
+// Serialize converts a Game into SGF format.
+// Calls serializeHelper.
+func Serialize(g *game.Game) string {
+	return fmt.Sprintf("(%s)", serializeHelper(g.Root))
+}
+
+// serializeHelper is a recursive DFS searching all
+// descendant nodes of n.
+func serializeHelper(n *game.Node) string {
+	var sb strings.Builder
+	sb.WriteString(writeNode(n))
+	for _, child := range n.Children {
+		if len(n.Children) > 1 {
+			sb.WriteString(fmt.Sprintf("(%s)", serializeHelper(child)))
+		} else {
+			sb.WriteString(serializeHelper(child))
+		}
+	}
+	return sb.String()
+}
+
+// writeNode writes a node in SGF format
+func writeNode(n *game.Node) string {
+	var sb strings.Builder
+
+	sb.WriteString(";")
+	for key := range n.Properties {
+		sb.WriteString(key)
+		for _, value := range n.Properties[key] {
+			sb.WriteString(fmt.Sprintf("[%s]", value))
+		}
+	}
+	return sb.String()
+}

--- a/core/sgf/serialize.go
+++ b/core/sgf/serialize.go
@@ -2,6 +2,7 @@ package sgf
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/otrego/clamshell/core/game"
@@ -33,6 +34,12 @@ func writeNode(n *game.Node) string {
 	var sb strings.Builder
 
 	sb.WriteString(";")
+	keys := make([]string, 0)
+	for key := range n.Properties {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
 	for key := range n.Properties {
 		sb.WriteString(key)
 		for _, value := range n.Properties[key] {

--- a/core/sgf/serialize_test.go
+++ b/core/sgf/serialize_test.go
@@ -1,0 +1,111 @@
+package sgf_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/otrego/clamshell/core/game"
+	"github.com/otrego/clamshell/core/sgf"
+)
+
+func TestSerialize(t *testing.T) {
+	testCases := []struct {
+		desc string
+		sgf  string
+	}{
+		{
+			desc: "black move",
+			sgf:  "(;GM[1];B[ab])",
+		},
+		{
+			desc: "white move",
+			sgf:  "(;GM[1];W[ab])",
+		},
+		{
+			desc: "black & white placements",
+			sgf:  "(;GM[1];AB[ab][ac]AW[bb][bc])",
+		},
+		{
+			desc: "complex problem",
+			sgf: `
+(;GM[1]FF[4]CA[UTF-8]AP[Glift]ST[2]
+RU[Japanese]SZ[19]KM[0.00]
+C[Black to play. There aren't many options
+to choose from, but you might be surprised at the answer!]
+PW[White]PB[Black]AW[pa][qa][nb][ob][qb][oc][pc][md][pd][ne][oe]
+AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
+(;B[mc]
+	;W[nc]C[White lives.])
+(;B[ma]
+	(;W[oa]
+		;B[nc]
+		;W[nd]
+		;B[mc]C[White dies.]GB[1])
+	(;W[mc]
+		(;B[oa]
+		;W[nd]
+		;B[pb]C[White lives])
+		(;B[nd]
+			;W[nc]
+			;B[oa]C[White dies.]GB[1]))
+	(;W[nd]
+		;B[mc]
+		;W[oa]
+		;B[nc]C[White dies.]GB[1]))
+(;B[nc]
+	;W[mc]C[White lives])
+(;B[]C[A default consideration]
+	;W[mc]C[White lives easily]))`,
+		},
+		{
+			desc: "mega mark test",
+			sgf: `
+(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]
+RU[Japanese]SZ[19]KM[0.00]
+PW[White]PB[Black]
+AW[na][oa][pa][qa][ra][sa][ka][la][ma][ja]
+AB[nb][ob][pb][qb][rb][sb][kb][lb][mb][jb]
+LB[pa:A][ob:2][pb:B][pc:C][pd:D]
+[oa:1][oc:3][ne:9][oe:8][pe:7][qe:6][re:5][se:4]
+[nf:15][of:14][pf:13][qf:11][rf:12][sf:10]
+[ng:22][og:44][pg:100]
+[ka:a][kb:b][kc:c][kd:d][ke:e][kf:f][kg:g]
+[ma:\u4e00][mb:\u4e8c][mc:\u4e09][md:\u56db][me:\u4e94]
+[la:\u516d][lb:\u4e03][lc:\u516b][ld:\u4e5d][le:\u5341]
+MA[na][nb][nc]
+CR[qa][qb][qc]
+TR[sa][sb][sc]
+SQ[ra][rb][rc]
+)`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			//Create game
+			g, err := sgf.Parse(tc.sgf)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			//convert original game back to sgf, then back to new game
+			got, err := sgf.Parse(sgf.Serialize(g))
+
+			//check if both games are identical
+			var sbWant strings.Builder
+			var sbGot strings.Builder
+			g.Root.Traverse(func(n *game.Node) {
+				sbWant.WriteString(fmt.Sprintf("%v", n.Properties))
+			})
+
+			got.Root.Traverse(func(n *game.Node) {
+				sbGot.WriteString(fmt.Sprintf("%v", n.Properties))
+			})
+
+			if sbWant.String() != sbGot.String() {
+				t.Errorf("want:\n%s\ngot%s", sbWant.String(), sbGot.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moved sgf.Serialize into it's own file, sgf/serialize. Serialize also sorts properties before converting the game tree to sgf format.

Fixes: #138