### PR TITLE
Move treepath into Game

### DIFF
--- a/core/game/treepath.go
+++ b/core/game/treepath.go
@@ -1,10 +1,4 @@
-// Package treepath provides functionality for manipulating treepaths.
-//
-// Treepaths are string-encodings of paths through trees.
-//
-// Treepaths come originially from
-// https://github.com/Kashomon/glift-core/blob/master/src/rules/treepath.js
-package treepath
+package game
 
 import (
 	"fmt"
@@ -40,7 +34,7 @@ const (
 	repeatState
 )
 
-// Parse parses a treepath from a string to an array of ints (Treepath).
+// ParsePath parses a treepath from a string to an array of ints (Treepath).
 //
 // There are a couple different string short-hands that make using treepaths
 // a little easier
@@ -65,7 +59,7 @@ const (
 //    0:4           becomes [0,0,0,0]
 //    1:4           becomes [1,1,1,1]
 //    1.2:1.0.2:3   becomes [1,2,0,2,2,2]
-func Parse(path string) (Treepath, error) {
+func ParsePath(path string) (Treepath, error) {
 	out := Treepath{}
 	curState := variationState
 	buf := strings.Builder{}

--- a/core/game/treepath.go
+++ b/core/game/treepath.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-
-	"github.com/otrego/clamshell/core/game"
 )
 
 // A Treepath is a list of variations that says how to travel through a tree of
@@ -159,7 +157,7 @@ func ParsePath(path string) (Treepath, error) {
 //
 // 1. There are no more variation numbers in the treepath.
 // 2. There is not a child with the given variation number.
-func (tp Treepath) Apply(n *game.Node) *game.Node {
+func (tp Treepath) Apply(n *Node) *Node {
 	curNode := n
 	for _, v := range tp {
 		if v < len(curNode.Children) {

--- a/core/game/treepath_test.go
+++ b/core/game/treepath_test.go
@@ -1,10 +1,11 @@
-package game
+package game_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/otrego/clamshell/core/errcheck"
+	"github.com/otrego/clamshell/core/game"
 	"github.com/otrego/clamshell/core/sgf"
 )
 
@@ -115,7 +116,7 @@ func TestParsePath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := ParsePath(tc.path)
+			got, err := game.ParsePath(tc.path)
 
 			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
 			if cerr != nil {
@@ -126,7 +127,7 @@ func TestParsePath(t *testing.T) {
 				return
 			}
 
-			if !cmp.Equal(got, Treepath(tc.exp)) {
+			if !cmp.Equal(got, game.Treepath(tc.exp)) {
 				t.Errorf("ParsePath(%v)=%v, but expected %v", tc.path, got, tc.exp)
 			}
 		})
@@ -142,10 +143,10 @@ func TestApplyPath(t *testing.T) {
 	}{
 		{
 			desc: "first move",
-			path: "0",
+			path: ".0",
 			game: "(;GM[1];B[pd]C[foo])",
 			expProps: map[string][]string{
-				"C": []string{"zed"},
+				"C": []string{"foo"},
 				"B": []string{"pd"},
 			},
 		},
@@ -158,7 +159,7 @@ func TestApplyPath(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			path, err := ParsePath(tc.path)
+			path, err := game.ParsePath(tc.path)
 			if err != nil {
 				t.Error(err)
 				return
@@ -176,7 +177,7 @@ func TestString(t *testing.T) {
 
 	testCases := []struct {
 		desc string
-		tp   Treepath
+		tp   game.Treepath
 		exp  string
 	}{
 		{
@@ -208,7 +209,7 @@ func TestString(t *testing.T) {
 func TestCompactString(t *testing.T) {
 	testCases := []struct {
 		desc string
-		tp   Treepath
+		tp   game.Treepath
 		exp  string
 	}{
 		{

--- a/core/game/treepath_test.go
+++ b/core/game/treepath_test.go
@@ -1,4 +1,4 @@
-package treepath
+package game
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	"github.com/otrego/clamshell/core/sgf"
 )
 
-func TestParse(t *testing.T) {
+func TestParsePath(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		path         string
@@ -115,7 +115,7 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := Parse(tc.path)
+			got, err := ParsePath(tc.path)
 
 			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
 			if cerr != nil {
@@ -127,7 +127,7 @@ func TestParse(t *testing.T) {
 			}
 
 			if !cmp.Equal(got, Treepath(tc.exp)) {
-				t.Errorf("Parse(%v)=%v, but expected %v", tc.path, got, tc.exp)
+				t.Errorf("ParsePath(%v)=%v, but expected %v", tc.path, got, tc.exp)
 			}
 		})
 	}
@@ -136,21 +136,21 @@ func TestParse(t *testing.T) {
 func TestApplyPath(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		initPath string
+		path     string
 		game     string
 		expProps map[string][]string
 	}{
 		{
-			desc:     "first move",
-			initPath: "0",
-			game:     "(;GM[1];B[pd]C[foo])",
+			desc: "first move",
+			path: "0",
+			game: "(;GM[1];B[pd]C[foo])",
 			expProps: map[string][]string{
 				"C": []string{"zed"},
 				"B": []string{"pd"},
 			},
 		},
 	}
-	t.Skip("Parsing is currently incorrect:Re-enable test once https://github.com/otrego/clamshell/issues/83 is fixed")
+
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			g, err := sgf.FromString(tc.game).Parse()
@@ -158,7 +158,7 @@ func TestApplyPath(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			path, err := Parse(tc.initPath)
+			path, err := ParsePath(tc.path)
 			if err != nil {
 				t.Error(err)
 				return

--- a/core/katago/analysis_result_test.go
+++ b/core/katago/analysis_result_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/otrego/clamshell/core/game"
 	"github.com/otrego/clamshell/core/sgf"
-	"github.com/otrego/clamshell/core/treepath"
 )
 
 func TestParseResult_Short(t *testing.T) {
@@ -193,7 +193,7 @@ func TestAddToGame(t *testing.T) {
 				t.Fatal(err)
 			}
 			for tpRaw, valp := range tc.expWinRate {
-				tp, err := treepath.Parse(tpRaw)
+				tp, err := game.ParsePath(tpRaw)
 				if err != nil {
 					t.Error(err)
 					continue

--- a/core/katago/kataprob/kataprob.go
+++ b/core/katago/kataprob/kataprob.go
@@ -5,10 +5,9 @@ package kataprob
 
 import (
 	"github.com/otrego/clamshell/core/game"
-	"github.com/otrego/clamshell/core/treepath"
 )
 
 // FindBlunders finds positions (paths) that result from big swings in points.
-func FindBlunders(g *game.Game) ([]treepath.Treepath, error) {
+func FindBlunders(g *game.Game) ([]game.Treepath, error) {
 	return nil, nil
 }

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/otrego/clamshell/core/move"
 	"github.com/otrego/clamshell/core/point"
 	"github.com/otrego/clamshell/core/sgf"
-	"github.com/otrego/clamshell/core/treepath"
 )
 
 type propmap map[string][]string
@@ -244,7 +243,7 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 			}
 
 			for path, pmap := range tc.pathToProps {
-				tp, err := treepath.Parse(path)
+				tp, err := game.ParsePath(path)
 				if err != nil {
 					t.Error(err)
 					continue
@@ -314,7 +313,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			tp, err := treepath.Parse(tc.path)
+			tp, err := game.ParsePath(tc.path)
 			if err != nil {
 				t.Error(err)
 				return

--- a/katalyze/main.go
+++ b/katalyze/main.go
@@ -33,10 +33,10 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/otrego/clamshell/core/game"
 	"github.com/otrego/clamshell/core/katago"
 	"github.com/otrego/clamshell/core/katago/kataprob"
 	"github.com/otrego/clamshell/core/sgf"
-	"github.com/otrego/clamshell/core/treepath"
 )
 
 var (
@@ -120,7 +120,7 @@ func process(files []string, an *katago.Analyzer) error {
 			return err
 		}
 
-		var positions []treepath.Treepath
+		var positions []game.Treepath
 		if paths, err := kataprob.FindBlunders(g); err != nil {
 			positions = append(positions, paths...)
 		} else {


### PR DESCRIPTION
Treepath is intimately tied with 'game` with is really more of a movetree. So, it makes the most sense to me to move it into the game package.

As a follow up, I think that `game` should be renamed `movetree` or similar. 

Fixes #135 