### PR TITLE
Add a find-blunders method

### DIFF
--- a/core/katago/analysis_result.go
+++ b/core/katago/analysis_result.go
@@ -87,14 +87,14 @@ func (al AnalysisList) AddToGame(g *game.Game) error {
 
 	if len(alc) == 0 {
 		// Degenerate case, but not an error per-se.
-		return nil
+		return errors.New("during AddToGame, no analysis data")
 	}
 
 	// Here we assume the AnalysisList is sorted.
 	curNode := g.Root
 	if curNode == nil {
 		// Degenerate case.
-		return errors.New("nil root node")
+		return errors.New("during AddToGame, nil root node")
 	}
 
 	anIdx := 0

--- a/core/katago/analysis_result_test.go
+++ b/core/katago/analysis_result_test.go
@@ -148,15 +148,6 @@ func TestAddToGame(t *testing.T) {
 		expWinRate map[string]*float64
 	}{
 		{
-			desc:   "degenerate case",
-			rawSgf: `(;GM[1];B[ac];W[cd];B[de])`,
-			expWinRate: map[string]*float64{
-				".":    nil,
-				".0":   nil,
-				".0.0": nil,
-			},
-		},
-		{
 			desc:   "basic attachment",
 			rawSgf: `(;GM[1];B[ac];W[cd];B[de])`,
 			analysis: AnalysisList{

--- a/core/katago/kataprob/kataprob.go
+++ b/core/katago/kataprob/kataprob.go
@@ -5,10 +5,49 @@ package kataprob
 
 import (
 	"github.com/otrego/clamshell/core/game"
+	"github.com/otrego/clamshell/core/katago"
 	"github.com/otrego/clamshell/core/treepath"
 )
 
 // FindBlunders finds positions (paths) that result from big swings in points.
 func FindBlunders(g *game.Game) ([]treepath.Treepath, error) {
-	return nil, nil
+	blunderAmt := -10.0
+
+	var cur treepath.Treepath
+	var found []treepath.Treepath
+	if g.Root == nil {
+		return found, nil
+	}
+
+	var prevLead float64
+
+	for n := g.Root.Next(0); n != nil; n = n.Next(0) {
+		// We assume alternating moves. Lead is always presented as
+		pl := prevLead
+		cur = append(cur, n.VarNum())
+
+		d := n.AnalysisData()
+		if d != nil {
+			continue
+		}
+
+		katad, ok := d.(katago.AnalysisResult)
+		if !ok {
+			continue
+		}
+		if katad.RootInfo == nil {
+			continue
+		}
+
+		lead := katad.RootInfo.ScoreLead
+		delta := lead - pl
+		if delta <= blunderAmt {
+			found = append(found, cur.Clone())
+		}
+
+		// prevLead is always with respect to current player
+		prevLead = -1 * lead
+	}
+
+	return found, nil
 }

--- a/core/katago/kataprob/kataprob.go
+++ b/core/katago/kataprob/kataprob.go
@@ -4,6 +4,9 @@
 package kataprob
 
 import (
+	"math"
+
+	"github.com/golang/glog"
 	"github.com/otrego/clamshell/core/game"
 	"github.com/otrego/clamshell/core/katago"
 	"github.com/otrego/clamshell/core/treepath"
@@ -11,7 +14,7 @@ import (
 
 // FindBlunders finds positions (paths) that result from big swings in points.
 func FindBlunders(g *game.Game) ([]treepath.Treepath, error) {
-	blunderAmt := -10.0
+	blunderAmt := 3.0
 
 	var cur treepath.Treepath
 	var found []treepath.Treepath
@@ -21,32 +24,42 @@ func FindBlunders(g *game.Game) ([]treepath.Treepath, error) {
 
 	var prevLead float64
 
-	for n := g.Root.Next(0); n != nil; n = n.Next(0) {
+	for n := g.Root; n != nil; n = n.Next(0) {
+		glog.Infof("VarNum %v\n", n.VarNum())
+		glog.Infof("MoveNum %v\n", n.MoveNum())
+
 		// We assume alternating moves. Lead is always presented as
 		pl := prevLead
 		cur = append(cur, n.VarNum())
+		glog.Infof("PrevLead %v\n", prevLead)
 
 		d := n.AnalysisData()
-		if d != nil {
+		if d == nil {
+			glog.Infof("nil analysis data")
 			continue
 		}
 
-		katad, ok := d.(katago.AnalysisResult)
+		katad, ok := d.(*katago.AnalysisResult)
 		if !ok {
+			glog.Infof("not analysisResult")
 			continue
 		}
 		if katad.RootInfo == nil {
+			glog.Infof("no RootInfo")
 			continue
 		}
 
 		lead := katad.RootInfo.ScoreLead
-		delta := lead - pl
-		if delta <= blunderAmt {
+		nextLead := -1 * lead
+		glog.Infof("Next ScoreLead: %v:", nextLead)
+		delta := nextLead - pl
+		glog.Infof("Delta: %v:", delta)
+		if delta >= math.Abs(blunderAmt) {
 			found = append(found, cur.Clone())
 		}
 
 		// prevLead is always with respect to current player
-		prevLead = -1 * lead
+		prevLead = nextLead
 	}
 
 	return found, nil

--- a/core/treepath/treepath.go
+++ b/core/treepath/treepath.go
@@ -191,6 +191,12 @@ func (tp Treepath) String() string {
 	return fmt.Sprintf("%v", strArr)
 }
 
+// Clone makes a copy of the treepath.
+func (tp Treepath) Clone() Treepath {
+	// A shallow copy should be sufficient.
+	return tp[:]
+}
+
 // CompactString returns the treepath as a CompactString (short-hand).
 // examples:
 //      []                  becomes "."

--- a/katalyze/main.go
+++ b/katalyze/main.go
@@ -128,7 +128,11 @@ func process(files []string, an *katago.Analyzer) error {
 		} else {
 			positions = append(positions, paths...)
 		}
-		glog.Infof("Found Positions: %v\n", positions)
+		var found []string
+		for _, tp := range positions {
+			found = append(found, tp.CompactString())
+		}
+		glog.Infof("Found Positions: %v", found)
 	}
 	return nil
 }

--- a/katalyze/main.go
+++ b/katalyze/main.go
@@ -133,11 +133,12 @@ func process(files []string, an *katago.Analyzer) error {
 		glog.Infof("Finished adding to game for file %q", fi)
 
 		var positions []game.Treepath
-		if paths, err := kataprob.FindBlunders(g); err != nil {
+		paths, err := kataprob.FindBlunders(g)
+		if err != nil {
 			return err
-		} else {
-			positions = append(positions, paths...)
 		}
+		positions = append(positions, paths...)
+
 		var found []string
 		for _, tp := range positions {
 			found = append(found, tp.CompactString())

--- a/katalyze/main.go
+++ b/katalyze/main.go
@@ -113,20 +113,22 @@ func process(files []string, an *katago.Analyzer) error {
 		if err != nil {
 			return err
 		}
-		glog.V(2).Infof("Finished processing: %v\n", result)
+		glog.Infof("Finished processing file %q", fi)
+		glog.V(2).Infof("Processing data: %v\n", result)
 
 		err = result.AddToGame(g)
 		if err != nil {
 			return err
 		}
+		glog.Infof("Finished adding to game for file %q", fi)
 
 		var positions []treepath.Treepath
 		if paths, err := kataprob.FindBlunders(g); err != nil {
-			positions = append(positions, paths...)
-		} else {
 			return err
+		} else {
+			positions = append(positions, paths...)
 		}
-		glog.V(2).Infof("Found Positions: %v\n", positions)
+		glog.Infof("Found Positions: %v\n", positions)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fleshes out the FindBlunders method. It's not very configurable, but it does work end-to-end

Example test-run:

```
kashomon@Joshs-Air:~/inprogress/clamshell (blunders)$ go run katalyze/main.go --config=katalyze/testdata/analysis_example.cfg --model=katalyze/testdata/g170e-b10c128-s1141046784-d204142634.bin.gz katalyze/testdata/example-game.sgf
I1125 21:36:17.982544   83641 katago.go:68] Starting Katago analyzer
I1125 21:36:17.982660   83641 katago.go:69] Using model "katalyze/testdata/g170e-b10c128-s1141046784-d204142634.bin.gz"
I1125 21:36:17.982685   83641 katago.go:70] Using gtp config "katalyze/testdata/analysis_example.cfg"
I1125 21:36:25.707929   83641 katago.go:87] Katago Startup Complete
I1125 21:36:25.707978   83641 main.go:103] using files [katalyze/testdata/example-game.sgf]
I1125 21:36:25.708011   83641 main.go:105] Processing file "katalyze/testdata/example-game.sgf"
I1125 21:36:39.888000   83641 main.go:126] Finished processing file "katalyze/testdata/example-game.sgf"
I1125 21:36:39.888056   83641 main.go:133] Finished adding to game for file "katalyze/testdata/example-game.sgf"
I1125 21:36:39.888253   83641 main.go:146] Found Positions: [.0:64 .0:72 .0:80 .0:86 .0:92 .0:96 .0:100 .0:108 .0:122 .0:124 .0:134 .0:138]
I1125 21:36:39.888303   83641 katago.go:196] Shutting down Katago analyzer
```

Some miscellaneous changes:
- Make a treepath-clone helper
- Add better input-validation for katalyze `main.go`
- Fix flag: analysisThreads => analysis_threads