### PR TITLE
Rework property parsing using converter pattern

### DIFF
--- a/core/move/move.go
+++ b/core/move/move.go
@@ -19,6 +19,11 @@ func NewMove(col color.Color, pt *point.Point) *Move {
 	return &Move{color: col, point: pt}
 }
 
+// NewPass creates a a new pass Move.
+func NewPass(col color.Color) *Move {
+	return &Move{color: col, point: nil}
+}
+
 // Color returns the color.
 func (m *Move) Color() color.Color {
 	return m.color

--- a/core/movetree/node.go
+++ b/core/movetree/node.go
@@ -34,6 +34,10 @@ type Node struct {
 	analysisData interface{}
 }
 
+// RootProperties
+type RootProperties struct {
+}
+
 // NewNode creates a Node.
 func NewNode() *Node {
 	return &Node{

--- a/core/movetree/node.go
+++ b/core/movetree/node.go
@@ -34,10 +34,6 @@ type Node struct {
 	analysisData interface{}
 }
 
-// RootProperties
-type RootProperties struct {
-}
-
 // NewNode creates a Node.
 func NewNode() *Node {
 	return &Node{

--- a/core/movetree/treepath_test.go
+++ b/core/movetree/treepath_test.go
@@ -144,10 +144,10 @@ func TestApplyPath(t *testing.T) {
 		{
 			desc: "first move",
 			path: ".0",
-			game: "(;GM[1];B[pd]C[foo])",
+			game: "(;GM[1];PM[1]B[pd]C[foo])",
 			expProps: map[string][]string{
-				"C": []string{"foo"},
-				"B": []string{"pd"},
+				"C":  []string{"foo"},
+				"PM": []string{"1"},
 			},
 		},
 	}

--- a/core/prop/converters.go
+++ b/core/prop/converters.go
@@ -1,0 +1,160 @@
+package prop
+
+import (
+	"fmt"
+
+	"github.com/otrego/clamshell/core/color"
+	"github.com/otrego/clamshell/core/move"
+	"github.com/otrego/clamshell/core/movetree"
+)
+
+// converters contain all the property converters.
+var converters = []*Converter{
+	// Black Placements
+	&Converter{
+		Prop: "AB",
+		From: func(n *movetree.Node, data []string) error {
+			moves, err := move.ListFromSGFPoints(color.Black, data)
+			if err != nil {
+				return err
+			}
+			n.Placements = append(n.Placements, moves...)
+			return nil
+		},
+		To: func(n *movetree.Node) ([]string, error) {
+			var out []string
+			for _, mv := range n.Placements {
+				if mv.Color() != color.Black {
+					continue
+				}
+				sgfPt, err := mv.Point().ToSGF()
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, sgfPt)
+			}
+			return out, nil
+		},
+	},
+
+	// White Placements
+	&Converter{
+		Prop: "AW",
+		From: func(n *movetree.Node, data []string) error {
+			moves, err := move.ListFromSGFPoints(color.White, data)
+			if err != nil {
+				return err
+			}
+			n.Placements = append(n.Placements, moves...)
+			return nil
+		},
+		To: func(n *movetree.Node) ([]string, error) {
+			var out []string
+			for _, mv := range n.Placements {
+				if mv.Color() != color.White {
+					continue
+				}
+				sgfPt, err := mv.Point().ToSGF()
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, sgfPt)
+			}
+			return out, nil
+		},
+	},
+
+	// Black Moves
+	&Converter{
+		Prop: "B",
+		From: func(n *movetree.Node, data []string) error {
+			if n.Move != nil {
+				return fmt.Errorf("found two moves on one node")
+			}
+			if len(data) != 1 && len(data) != 0 {
+				return fmt.Errorf("expected black move data to have exactly one value or zero values")
+			}
+			if len(data) == 0 {
+				data = []string{""}
+			}
+			move, err := move.FromSGFPoint(color.Black, data[0])
+			if err != nil {
+				return err
+			}
+			n.Move = move
+			return nil
+		},
+		To: func(n *movetree.Node) ([]string, error) {
+			mv := n.Move
+			if mv.Color() != color.Black {
+				return nil, nil
+			}
+			if mv.IsPass() {
+				// Return non-nil slice to indicate it should be stored.
+				return []string{}, nil
+			}
+			sgfPt, err := mv.Point().ToSGF()
+			if err != nil {
+				return nil, err
+			}
+			return []string{sgfPt}, nil
+		},
+	},
+
+	// White Moves
+	&Converter{
+		Prop: "W",
+		From: func(n *movetree.Node, data []string) error {
+			if n.Move != nil {
+				return fmt.Errorf("found two moves on one node")
+			}
+			if len(data) != 1 && len(data) != 0 {
+				return fmt.Errorf("expected white move data to have exactly one or zero values")
+			}
+			if len(data) == 0 {
+				data = []string{""}
+			}
+			move, err := move.FromSGFPoint(color.Black, data[0])
+			if err != nil {
+				return err
+			}
+			n.Move = move
+			return nil
+		},
+		To: func(n *movetree.Node) ([]string, error) {
+			mv := n.Move
+			if mv.Color() != color.Black {
+				return nil, nil
+			}
+			if mv.IsPass() {
+				// Return non-nil slice to indicate it should be stored as such.
+				return []string{}, nil
+			}
+			sgfPt, err := mv.Point().ToSGF()
+			if err != nil {
+				return nil, err
+			}
+			return []string{sgfPt}, nil
+		},
+	},
+}
+
+var convMap = func(conv []*Converter) map[Prop]*Converter {
+	mp := make(map[Prop]*Converter)
+	for _, c := range conv {
+		mp[c.Prop] = c
+	}
+	return mp
+}(converters)
+
+// HasConverter indicates whether there's a known SGF Property converter.
+func HasConverter(prop string) bool {
+	_, ok := convMap[Prop(prop)]
+	return ok
+}
+
+// PropConverter gets a property converter, returning nil if no property
+// converter can be found.
+func PropConverter(prop string) *Converter {
+	return convMap[Prop(prop)]
+}

--- a/core/prop/converters.go
+++ b/core/prop/converters.go
@@ -2,74 +2,108 @@ package prop
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/otrego/clamshell/core/color"
 	"github.com/otrego/clamshell/core/move"
 	"github.com/otrego/clamshell/core/movetree"
 )
 
+// Scope indicates the scope for a property.
+type Scope string
+
+const (
+	// RootScope indicates a property that only applies to the root node.
+	RootScope Scope = "RootScope"
+
+	// AllScope indicates a property that applies to all nodes.
+	AllScope Scope = "AllScope"
+)
+
+// FromSGF converts an SGF Property to node property
+type FromSGF func(node *movetree.Node, prop string, values []string) error
+
+// ToSGF converts an Node property to an SGF property list.
+type ToSGF func(node *movetree.Node) (string, error)
+
+// A SGFConverter converts SGF properties to / from node properties.
+type SGFConverter struct {
+	// Props is the name of the SGF properties that apply to this
+	// property-converter.
+	// Ex: {"AW", "AB"}
+	Props []Prop
+	// Scope indicates what the property-converter applies to (Root, All)
+	Scope Scope
+	// From converts from SGF data
+	From FromSGF
+	// To converts to SGF data
+	To ToSGF
+}
+
 // converters contain all the property converters.
-var converters = []*Converter{
-	// Black Placements
-	&Converter{
-		Prop: "AB",
-		From: func(n *movetree.Node, data []string) error {
-			moves, err := move.ListFromSGFPoints(color.Black, data)
+var converters = []*SGFConverter{
+	// Placements
+	&SGFConverter{
+		Props: []Prop{"AB", "AW"},
+		Scope: AllScope,
+		From: func(n *movetree.Node, prop string, data []string) error {
+			col, err := color.FromSGFProp(prop)
+			if err != nil {
+				return err
+			}
+			moves, err := move.ListFromSGFPoints(col, data)
 			if err != nil {
 				return err
 			}
 			n.Placements = append(n.Placements, moves...)
 			return nil
 		},
-		To: func(n *movetree.Node) ([]string, error) {
-			var out []string
+		To: func(n *movetree.Node) (string, error) {
+			if len(n.Placements) == 0 {
+				return "", nil
+			}
+			var black []string
+			var white []string
 			for _, mv := range n.Placements {
-				if mv.Color() != color.Black {
-					continue
-				}
 				sgfPt, err := mv.Point().ToSGF()
 				if err != nil {
-					return nil, err
+					return "", err
 				}
-				out = append(out, sgfPt)
+				if mv.Color() == color.Black {
+					black = append(black, sgfPt)
+				} else if mv.Color() == color.White {
+					white = append(white, sgfPt)
+				}
 			}
-			return out, nil
+			var out strings.Builder
+			if len(black) > 0 {
+				out.WriteString("AB")
+			}
+			for _, pt := range black {
+				out.WriteString("[" + pt + "]")
+			}
+			if len(white) > 0 {
+				out.WriteString("AW")
+			}
+			for _, pt := range white {
+				out.WriteString("[" + pt + "]")
+			}
+			return out.String(), nil
 		},
 	},
 
-	// White Placements
-	&Converter{
-		Prop: "AW",
-		From: func(n *movetree.Node, data []string) error {
-			moves, err := move.ListFromSGFPoints(color.White, data)
+	// Moves
+	&SGFConverter{
+		Props: []Prop{"B", "W"},
+		Scope: AllScope,
+		From: func(n *movetree.Node, prop string, data []string) error {
+			col, err := color.FromSGFProp(prop)
 			if err != nil {
 				return err
 			}
-			n.Placements = append(n.Placements, moves...)
-			return nil
-		},
-		To: func(n *movetree.Node) ([]string, error) {
-			var out []string
-			for _, mv := range n.Placements {
-				if mv.Color() != color.White {
-					continue
-				}
-				sgfPt, err := mv.Point().ToSGF()
-				if err != nil {
-					return nil, err
-				}
-				out = append(out, sgfPt)
-			}
-			return out, nil
-		},
-	},
-
-	// Black Moves
-	&Converter{
-		Prop: "B",
-		From: func(n *movetree.Node, data []string) error {
 			if n.Move != nil {
-				return fmt.Errorf("found two moves on one node")
+				return fmt.Errorf("found two moves on one node at move")
 			}
 			if len(data) != 1 && len(data) != 0 {
 				return fmt.Errorf("expected black move data to have exactly one value or zero values")
@@ -77,84 +111,85 @@ var converters = []*Converter{
 			if len(data) == 0 {
 				data = []string{""}
 			}
-			move, err := move.FromSGFPoint(color.Black, data[0])
+			move, err := move.FromSGFPoint(col, data[0])
 			if err != nil {
 				return err
 			}
 			n.Move = move
 			return nil
 		},
-		To: func(n *movetree.Node) ([]string, error) {
+		To: func(n *movetree.Node) (string, error) {
 			mv := n.Move
-			if mv.Color() != color.Black {
-				return nil, nil
+			if mv == nil {
+				return "", nil
+			}
+			var col string
+			if mv.Color() == color.Black {
+				col = "B"
+			} else if mv.Color() == color.White {
+				col = "W"
 			}
 			if mv.IsPass() {
 				// Return non-nil slice to indicate it should be stored.
-				return []string{}, nil
+				return col + "[]", nil
 			}
 			sgfPt, err := mv.Point().ToSGF()
 			if err != nil {
-				return nil, err
+				return "", err
 			}
-			return []string{sgfPt}, nil
-		},
-	},
-
-	// White Moves
-	&Converter{
-		Prop: "W",
-		From: func(n *movetree.Node, data []string) error {
-			if n.Move != nil {
-				return fmt.Errorf("found two moves on one node")
-			}
-			if len(data) != 1 && len(data) != 0 {
-				return fmt.Errorf("expected white move data to have exactly one or zero values")
-			}
-			if len(data) == 0 {
-				data = []string{""}
-			}
-			move, err := move.FromSGFPoint(color.Black, data[0])
-			if err != nil {
-				return err
-			}
-			n.Move = move
-			return nil
-		},
-		To: func(n *movetree.Node) ([]string, error) {
-			mv := n.Move
-			if mv.Color() != color.Black {
-				return nil, nil
-			}
-			if mv.IsPass() {
-				// Return non-nil slice to indicate it should be stored as such.
-				return []string{}, nil
-			}
-			sgfPt, err := mv.Point().ToSGF()
-			if err != nil {
-				return nil, err
-			}
-			return []string{sgfPt}, nil
+			return col + "[" + sgfPt + "]", nil
 		},
 	},
 }
 
-var convMap = func(conv []*Converter) map[Prop]*Converter {
-	mp := make(map[Prop]*Converter)
+var propToConv = func(conv []*SGFConverter) map[Prop]*SGFConverter {
+	mp := make(map[Prop]*SGFConverter)
 	for _, c := range conv {
-		mp[c.Prop] = c
+		for _, p := range c.Props {
+			mp[p] = c
+		}
 	}
 	return mp
 }(converters)
 
 // HasConverter indicates whether there's a known SGF Property converter.
 func HasConverter(prop string) bool {
-	_, ok := convMap[Prop(prop)]
+	_, ok := propToConv[Prop(prop)]
 	return ok
 }
 
-// PropConverter gets a property converter, returning nil if no property
-// converter can be found.
-func PropConverter(prop string) *Converter {
-	return convMap[Prop(prop)]
+// Converter gets a property converter for converting to/from SGf, returning nil
+// if no property converter can be found.
+func Converter(prop string) *SGFConverter {
+	return propToConv[Prop(prop)]
+}
+
+// ConvertNode converts all the properties in a node
+func ConvertNode(n *movetree.Node) (string, error) {
+	var sb strings.Builder
+	for _, c := range converters {
+		if c.Scope == RootScope && n.MoveNum() != 0 {
+			// skip non-root-scoped properties for non-root nodes.
+			continue
+		}
+		s, err := c.To(n)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(s)
+	}
+
+	var keys []string
+	for key := range n.Properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		sb.WriteString(key)
+		for _, value := range n.Properties[key] {
+			sb.WriteString("[" + value + "]")
+		}
+	}
+	return sb.String(), nil
 }

--- a/core/prop/converters_test.go
+++ b/core/prop/converters_test.go
@@ -1,0 +1,107 @@
+package prop
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/otrego/clamshell/core/color"
+	"github.com/otrego/clamshell/core/errcheck"
+	"github.com/otrego/clamshell/core/move"
+	"github.com/otrego/clamshell/core/movetree"
+	"github.com/otrego/clamshell/core/point"
+)
+
+type propGetter func(*movetree.Node) interface{}
+
+type setprops func(*movetree.Node) *movetree.Node
+
+func TestConverters_From(t *testing.T) {
+	testCases := []struct {
+		desc string
+		prop string
+		data []string
+
+		expNode      *movetree.Node
+		expErrSubstr string
+	}{
+		{
+			desc: "black move: pass",
+			prop: "B",
+			data: []string{},
+			expNode: func(n *movetree.Node) *movetree.Node {
+				n.Move = move.NewPass(color.Black)
+				return n
+			}(movetree.NewNode()),
+		},
+		{
+			desc: "black move: pass v2",
+			prop: "B",
+			data: []string{""},
+			expNode: func(n *movetree.Node) *movetree.Node {
+				n.Move = move.NewPass(color.Black)
+				return n
+			}(movetree.NewNode()),
+		},
+		{
+			desc: "black move",
+			prop: "B",
+			data: []string{"ab"},
+			expNode: func(n *movetree.Node) *movetree.Node {
+				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				return n
+			}(movetree.NewNode()),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			n := movetree.NewNode()
+			conv := PropConverter(tc.prop)
+			if conv == nil {
+				t.Fatal("expected converter, but found none")
+			}
+			if tc.prop != string(conv.Prop) {
+				t.Errorf("got converter with prop %q, but expected it to be %q", tc.prop, conv.Prop)
+			}
+			err := conv.From(n, tc.data)
+			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
+			if cerr != nil {
+				t.Fatal(cerr)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(n, tc.expNode) {
+				t.Errorf("got node %v, but expected node %v", n, tc.expNode)
+			}
+		})
+	}
+}
+
+func TestConverters_To(t *testing.T) {
+	testCases := []struct {
+		desc string
+		prop string
+		n    *movetree.Node
+
+		expData      []string
+		expErrSubstr string
+	}{
+		{
+			desc: "black move: pass",
+			prop: "B",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			conv := PropConverter(tc.prop)
+			if conv == nil {
+				t.Fatal("expected converter, but found none")
+			}
+			if tc.prop != string(conv.Prop) {
+				t.Errorf("got converter with prop %q, but expected it to be %q", tc.prop, conv.Prop)
+			}
+		})
+	}
+}

--- a/core/prop/prop.go
+++ b/core/prop/prop.go
@@ -1,11 +1,17 @@
 // Package prop adds methods for handling SGF properties, including validation.
 package prop
 
-// Field is used to store a label parsed from SGF
-type Field string
+import (
+	"strings"
+
+	"github.com/otrego/clamshell/core/movetree"
+)
+
+// Prop is used to store a label parsed from SGF
+type Prop string
 
 // ValidProperties lists all valid SGF properties
-var ValidProperties = map[Field]bool{"AB": true, "AE": true, "AN": true, "AP": true, "AR": true, "AW": true, "B": true, "BL": true, "BM": true, "BR": true,
+var ValidProperties = map[Prop]bool{"AB": true, "AE": true, "AN": true, "AP": true, "AR": true, "AW": true, "B": true, "BL": true, "BM": true, "BR": true,
 	"BT": true, "C": true, "CA": true, "CP": true, "CR": true, "DD": true, "DM": true, "DO": true, "DT": true, "EV": true, "FF": true, "FG": true, "GB": true,
 	"GC": true, "GM": true, "GN": true, "GW": true, "HA": true, "HO": true, "IT": true, "KM": true, "KO": true, "LB": true, "LN": true, "MA": true, "MN": true,
 	"N": true, "OB": true, "ON": true, "OT": true, "OW": true, "PB": true, "PC": true, "PL": true, "PM": true, "PW": true, "RE": true, "RO": true, "RU": true,
@@ -13,7 +19,40 @@ var ValidProperties = map[Field]bool{"AB": true, "AE": true, "AN": true, "AP": t
 	"VW": true, "W": true, "WL": true, "WR": true, "WT": true}
 
 // Validate returns true if Prop is an accepted SGF property.
-func Validate(field Field) bool {
-	_, ok := ValidProperties[field]
+func Validate(prop Prop) bool {
+	_, ok := ValidProperties[prop]
 	return ok
+}
+
+// FromSGF converts an SGF Property to node property
+type FromSGF func(node *movetree.Node, values []string) error
+
+// ToSGF converts an Node property to an SGF property list.
+type ToSGF func(node *movetree.Node) ([]string, error)
+
+// A Converter converts SGF properties to / from node properties.
+type Converter struct {
+	// Prop is the name of the SGF property. Ex: "AW"
+	Prop Prop
+	// From converts from SGF data
+	From FromSGF
+	// To converts to SGF data
+	To ToSGF
+}
+
+// BuildSGFString adds SGF content to a string builder.
+func (c *Converter) BuildSGFString(node *movetree.Node, sb *strings.Builder) error {
+	data, err := c.To(node)
+	if err != nil {
+		return err
+	}
+	sb.WriteString(string(c.Prop))
+	if data != nil && len(data) == 0 {
+		// Special case (mostly for passes)
+		sb.WriteString("[]")
+	}
+	for _, d := range data {
+		sb.WriteString("[" + d + "]")
+	}
+	return nil
 }

--- a/core/prop/prop.go
+++ b/core/prop/prop.go
@@ -1,12 +1,6 @@
 // Package prop adds methods for handling SGF properties, including validation.
 package prop
 
-import (
-	"strings"
-
-	"github.com/otrego/clamshell/core/movetree"
-)
-
 // Prop is used to store a label parsed from SGF
 type Prop string
 
@@ -22,37 +16,4 @@ var ValidProperties = map[Prop]bool{"AB": true, "AE": true, "AN": true, "AP": tr
 func Validate(prop Prop) bool {
 	_, ok := ValidProperties[prop]
 	return ok
-}
-
-// FromSGF converts an SGF Property to node property
-type FromSGF func(node *movetree.Node, values []string) error
-
-// ToSGF converts an Node property to an SGF property list.
-type ToSGF func(node *movetree.Node) ([]string, error)
-
-// A Converter converts SGF properties to / from node properties.
-type Converter struct {
-	// Prop is the name of the SGF property. Ex: "AW"
-	Prop Prop
-	// From converts from SGF data
-	From FromSGF
-	// To converts to SGF data
-	To ToSGF
-}
-
-// BuildSGFString adds SGF content to a string builder.
-func (c *Converter) BuildSGFString(node *movetree.Node, sb *strings.Builder) error {
-	data, err := c.To(node)
-	if err != nil {
-		return err
-	}
-	sb.WriteString(string(c.Prop))
-	if data != nil && len(data) == 0 {
-		// Special case (mostly for passes)
-		sb.WriteString("[]")
-	}
-	for _, d := range data {
-		sb.WriteString("[" + d + "]")
-	}
-	return nil
 }

--- a/core/prop/prop_test.go
+++ b/core/prop/prop_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	valid := prop.Field("TB")
+	valid := prop.Prop("TB")
 
 	test := prop.Validate(valid)
 	if test != true {
@@ -15,7 +15,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestInvalidate(t *testing.T) {
-	invalid := prop.Field("TQB")
+	invalid := prop.Prop("TQB")
 
 	test := prop.Validate(invalid)
 	if test != false {

--- a/core/sgf/serialize.go
+++ b/core/sgf/serialize.go
@@ -1,50 +1,51 @@
 package sgf
 
 import (
-	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/otrego/clamshell/core/movetree"
+	"github.com/otrego/clamshell/core/prop"
 )
 
 // Serialize converts a Game into SGF format.
 // Calls serializeHelper.
-func Serialize(g *movetree.MoveTree) string {
-	return fmt.Sprintf("(%s)", serializeHelper(g.Root))
+func Serialize(g *movetree.MoveTree) (string, error) {
+	s, err := serializeHelper(g.Root)
+	if err != nil {
+		return "", err
+	}
+	return "(" + s + ")", nil
 }
 
 // serializeHelper is a recursive DFS searching all
 // descendant nodes of n.
-func serializeHelper(n *movetree.Node) string {
+func serializeHelper(n *movetree.Node) (string, error) {
 	var sb strings.Builder
-	sb.WriteString(writeNode(n))
+	s, err := writeNode(n)
+	if err != nil {
+		return "", nil
+	}
+	sb.WriteString(s)
+
 	for _, child := range n.Children {
+		s, err := serializeHelper(child)
+		if err != nil {
+			return "", err
+		}
 		if len(n.Children) > 1 {
-			sb.WriteString(fmt.Sprintf("(%s)", serializeHelper(child)))
+			sb.WriteString("(" + s + ")")
 		} else {
-			sb.WriteString(serializeHelper(child))
+			sb.WriteString(s)
 		}
 	}
-	return sb.String()
+	return sb.String(), nil
 }
 
 // writeNode writes a node in SGF format
-func writeNode(n *movetree.Node) string {
-	var sb strings.Builder
-
-	sb.WriteString(";")
-	keys := make([]string, 0)
-	for key := range n.Properties {
-		keys = append(keys, key)
+func writeNode(n *movetree.Node) (string, error) {
+	s, err := prop.ConvertNode(n)
+	if err != nil {
+		return s, err
 	}
-
-	sort.Strings(keys)
-	for key := range n.Properties {
-		sb.WriteString(key)
-		for _, value := range n.Properties[key] {
-			sb.WriteString(fmt.Sprintf("[%s]", value))
-		}
-	}
-	return sb.String()
+	return ";" + s, nil
 }

--- a/core/sgf/serialize_test.go
+++ b/core/sgf/serialize_test.go
@@ -90,7 +90,11 @@ SQ[ra][rb][rc]
 			}
 
 			//convert original movetree back to sgf, then back to new game
-			got, err := sgf.Parse(sgf.Serialize(g))
+			serialized, err := sgf.Serialize(g)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := sgf.Parse(serialized)
 
 			//check if both movetrees are identical
 			var sbWant strings.Builder


### PR DESCRIPTION
This PR completely reworks the way property-parsing works.

The motivation is that currently there are two sources of truth -- the raw properties (in the prop-map) and the parsed properties (Move, Placements). In general, I think we tend towards the latter, but it requires some fairly significant changes.

- Each property that exists as a type on the Node gets a To/From converter.
- Any property that's Parsed in such a fashion is removed from the default Properties map
- Add extensive tests for to/from

