### PR TITLE
Move Treepath => Path and change compact string.

### DIFF
--- a/core/katago/analysis_result_test.go
+++ b/core/katago/analysis_result_test.go
@@ -167,10 +167,10 @@ func TestAddToGame(t *testing.T) {
 				},
 			},
 			expWinRate: map[string]*float64{
-				".":      nil,
-				".0":     floatPtr(0.1),
-				".0.0":   nil,
-				".0.0.0": floatPtr(0.3),
+				"-":      nil,
+				"-0":     floatPtr(0.1),
+				"-0-0":   nil,
+				"-0-0-0": floatPtr(0.3),
 			},
 		},
 	}

--- a/core/katago/kataprob/kataprob.go
+++ b/core/katago/kataprob/kataprob.go
@@ -12,11 +12,11 @@ import (
 )
 
 // FindBlunders finds positions (paths) that result from big swings in points.
-func FindBlunders(g *movetree.MoveTree) ([]movetree.Treepath, error) {
+func FindBlunders(g *movetree.MoveTree) ([]movetree.Path, error) {
 	blunderAmt := 3.0
 
-	var cur movetree.Treepath
-	var found []movetree.Treepath
+	var cur movetree.Path
+	var found []movetree.Path
 	if g.Root == nil {
 		return found, nil
 	}

--- a/core/movetree/treepath.go
+++ b/core/movetree/treepath.go
@@ -7,7 +7,7 @@ import (
 	"unicode"
 )
 
-// A Treepath is a list of variations that says how to travel through a tree of
+// A Path is a list of variations that says how to travel through a tree of
 // moves. And has two forms a list version and a string version. First, the
 // list-version:
 //
@@ -19,7 +19,7 @@ import (
 // the fun begins. At its simpliest,
 //
 //    [0,0,0] becomes 0.0.0
-type Treepath []int
+type Path []int
 
 type parseState int
 
@@ -32,14 +32,14 @@ const (
 	repeatState
 )
 
-// ParsePath parses a treepath from a string to an array of ints (Treepath).
+// ParsePath parses a treepath from a string to an array of ints (Path).
 //
 // There are a couple different string short-hands that make using treepaths
 // a little easier
 //
-//    0.1:2   Take the 0th variation, then repeat taking the 1st varation twice
+//    0-1x2   Take the 0th variation, then repeat taking the 1st varation twice
 //
-// Treepaths say how to get from position n to position m.  Thus the numbers are
+// Paths say how to get from position n to position m.  Thus the numbers are
 // always variations, separated by '.' except in the case of A:B syntax, which
 // means repeat A for B times.
 //
@@ -47,30 +47,30 @@ const (
 //
 // Some examples:
 //
-//    .             becomes []
+//    -             becomes []
 //    0             becomes [0]
-//    .0            becomes [0]
+//    -0            becomes [0]
 //    1             becomes [1]
 //    53            becomes [53] (the 53rd variation)
-//    2.3           becomes [2,3]
-//    0.0.0.0       becomes [0,0,0,0]
-//    0:4           becomes [0,0,0,0]
-//    1:4           becomes [1,1,1,1]
-//    1.2:1.0.2:3   becomes [1,2,0,2,2,2]
-func ParsePath(path string) (Treepath, error) {
-	out := Treepath{}
+//    2-3           becomes [2,3]
+//    0-0-0-0       becomes [0,0,0,0]
+//    0x4           becomes [0,0,0,0]
+//    1x4           becomes [1,1,1,1]
+//    1-2x1-0-2x3   becomes [1,2,0,2,2,2]
+func ParsePath(path string) (Path, error) {
+	out := Path{}
 	curState := variationState
 	buf := strings.Builder{}
 	prevChar := 0
 
 	// As a special case, just return the empty path as a degenerate case.
-	if path == "." || path == "" {
+	if path == "-" || path == "" {
 		return out, nil
 	}
 
 	convertBuffer := func(idx int) (int, error) {
 		if buf.Len() == 0 {
-			return 0, fmt.Errorf("error parsing path %v at index %d: separators '.', ':', EOL must be proceeded by digit", path, idx)
+			return 0, fmt.Errorf("error parsing path %v at index %d: separators '-', 'x', EOL must be proceeded by digit", path, idx)
 		}
 		n, err := strconv.Atoi(buf.String())
 		if err != nil {
@@ -87,15 +87,15 @@ func ParsePath(path string) (Treepath, error) {
 	// The rough approach is to have a simple parser modeled as a 2-state DFA.
 	//
 	// VARIATION: means we're parsing a normal variation number. We flush the
-	// buffer data when we hit a '.' rune.
+	// buffer data when we hit a '-' rune.
 	//
-	// REPEAT: means we have seen a ':' instead of a '.', so we're going to repeat
+	// REPEAT: means we have seen a 'x' instead of a '-', so we're going to repeat
 	// the previous number once we parse the next number.
 	//
-	//  --'.'--- <------------
+	//  --'-'--- <------------
 	//  |      |             |
 	//  V      ^             ^
-	// VARIATION --':'-->  REPEAT
+	// VARIATION --'x'-->  REPEAT
 	//   |                   V
 	//   EOL <----------------
 	//   |
@@ -104,9 +104,9 @@ func ParsePath(path string) (Treepath, error) {
 	for idx, c := range path {
 		if unicode.IsDigit(c) {
 			buf.WriteRune(c)
-		} else if c == '.' || c == '\n' {
+		} else if c == '-' || c == '\n' {
 			if idx == 0 {
-				// . is supported as an optional leading charactor. Just ignore.
+				// - is supported as an optional leading charactor. Just ignore.
 				continue
 			}
 			n, err := convertBuffer(idx)
@@ -128,7 +128,7 @@ func ParsePath(path string) (Treepath, error) {
 			} else {
 				return nil, fmt.Errorf("error parsing path %q at index %d: unknown state %v", path, idx, curState)
 			}
-		} else if c == ':' {
+		} else if c == 'x' {
 			n, err := convertBuffer(idx)
 			if err != nil {
 				return nil, err
@@ -157,7 +157,7 @@ func ParsePath(path string) (Treepath, error) {
 //
 // 1. There are no more variation numbers in the treepath.
 // 2. There is not a child with the given variation number.
-func (tp Treepath) Apply(n *Node) *Node {
+func (tp Path) Apply(n *Node) *Node {
 	curNode := n
 	for _, v := range tp {
 		if v < len(curNode.Children) {
@@ -175,7 +175,7 @@ func (tp Treepath) Apply(n *Node) *Node {
 //      []                  becomes "[]"
 //      [1]                 becomes "[1]"
 //      [1,2,0,2,2,2]       becomes "[1,2,0,2,2,2]"
-func (tp Treepath) String() string {
+func (tp Path) String() string {
 	var strArr []string
 	for _, i := range tp {
 		strArr = append(strArr, strconv.Itoa(i))
@@ -184,56 +184,47 @@ func (tp Treepath) String() string {
 }
 
 // Clone makes a copy of the treepath.
-func (tp Treepath) Clone() Treepath {
+func (tp Path) Clone() Path {
 	// A shallow copy should be sufficient.
 	return tp[:]
 }
 
 // CompactString returns the treepath as a CompactString (short-hand).
 // examples:
-//      []                  becomes "."
-//      [1]                 becomes ".1"
-//      [0,0,0,0]           becomes ".0:4"
-//      [1,1,1,1]           becomes ".1:4"
-//      [1,2,0,0,2,2,2]     becomes ".1.2.0:2.2:3"
-func (tp Treepath) CompactString() string {
+//      []                  becomes "-"
+//      [1]                 becomes "-1"
+//      [0,0,0,0]           becomes "-0x4"
+//      [1,1,1,1]           becomes "-1x4"
+//      [1,2,0,0,2,2,2]     becomes "-1-2-0x2-2x3"
+func (tp Path) CompactString() string {
 	var (
 		count, prev int = 1, -1
 		sb          strings.Builder
 	)
 
 	for _, v := range tp {
-
 		if v == prev {
 			//count repeated variation numbers.
 			count++
 		} else if count != 1 {
 			//write the repeated variation number.
-			sb.WriteString(fmt.Sprintf(".%d:%d", prev, count))
+			sb.WriteString(fmt.Sprintf("-%dx%d", prev, count))
 			count = 1
 		} else if prev != -1 {
 			//write non repeated variation number.
-			sb.WriteString(fmt.Sprintf(".%d", prev))
+			sb.WriteString(fmt.Sprintf("-%d", prev))
 		}
 		prev = v
 	}
 	if prev == -1 {
-		//empty treepath
-		sb.WriteString(".")
+		// empty path
+		sb.WriteString("-")
 	} else if count != 1 {
-		//end of treepath was a repeated variation number.
-		sb.WriteString(fmt.Sprintf(".%d:%d", prev, count))
+		// end of treepath was a repeated variation number.
+		sb.WriteString(fmt.Sprintf("-%dx%d", prev, count))
 	} else {
-		//end or treepath was a new variation number.
-		sb.WriteString(fmt.Sprintf(".%d", prev))
+		// end or treepath was a new variation number.
+		sb.WriteString(fmt.Sprintf("-%d", prev))
 	}
 	return sb.String()
-}
-
-// FileSafeCompactString returns a compact-string that can be used in
-func (tp Treepath) FileSafeCompactString() string {
-	s := tp.CompactString()
-	s = strings.ReplaceAll(s, ".", "-")
-	s = strings.ReplaceAll(s, ":", "x")
-	return s
 }

--- a/core/movetree/treepath_test.go
+++ b/core/movetree/treepath_test.go
@@ -22,8 +22,8 @@ func TestParsePath(t *testing.T) {
 			exp:  []int{},
 		},
 		{
-			desc: "empty treepath, using leading .",
-			path: ".",
+			desc: "empty treepath, using leading -",
+			path: "-",
 			exp:  []int{},
 		},
 		{
@@ -42,8 +42,8 @@ func TestParsePath(t *testing.T) {
 			exp:  []int{10},
 		},
 		{
-			desc: "move 2.3",
-			path: "2.3",
+			desc: "move 2-3",
+			path: "2-3",
 			exp:  []int{2, 3},
 		},
 		{
@@ -52,64 +52,64 @@ func TestParsePath(t *testing.T) {
 			exp:  []int{3},
 		},
 		{
-			desc: "variation 3, with leading .",
-			path: ".3",
+			desc: "variation 3, with leading -",
+			path: "-3",
 			exp:  []int{3},
 		},
 		{
-			desc: "move 2.0",
-			path: "2.0",
+			desc: "move 2-0",
+			path: "2-0",
 			exp:  []int{2, 0},
 		},
 		{
-			desc: "move 0.0.0.0 = 4 moves",
-			path: "0.0.0.0",
+			desc: "move 0-0-0-0 = 4 moves",
+			path: "0-0-0-0",
 			exp:  []int{0, 0, 0, 0},
 		},
 		{
-			desc: "move 0.0.0.0 = 4 moves, leading .",
-			path: ".0.0.0.0",
+			desc: "move 0-0-0-0 = 4 moves, leading -",
+			path: "-0-0-0-0",
 			exp:  []int{0, 0, 0, 0},
 		},
 		{
-			desc: "move 0.0:3 = 4 moves",
-			path: "0.0:3",
+			desc: "move 0-0x3 = 4 moves",
+			path: "0-0x3",
 			exp:  []int{0, 0, 0, 0},
 		},
 		{
-			desc: "move 0:4 = 4 moves",
-			path: "0:4",
+			desc: "move 0x4 = 4 moves",
+			path: "0x4",
 			exp:  []int{0, 0, 0, 0},
 		},
 		{
-			desc: "move 0:4 = 4 moves @ var 1",
-			path: "1:4",
+			desc: "move 0x4 = 4 moves @ var 1",
+			path: "1x4",
 			exp:  []int{1, 1, 1, 1},
 		},
 		{
 			desc: "complicated pattern",
-			path: "1.2:1.0.3:3",
+			path: "1-2x1-0-3x3",
 			exp:  []int{1, 2, 0, 3, 3, 3},
 		},
 		// Error cases
 		{
-			desc:         "move a:2 is invalid - not a number",
-			path:         "a:2",
+			desc:         "move ax2 is invalid - not a number",
+			path:         "ax2",
 			expErrSubstr: "unexpected char",
 		},
 		{
-			desc:         "move -1:2 is invalid - negatives are not allowed",
-			path:         "-1:2",
+			desc:         "move .1x2 is invalid - periods are not allowed",
+			path:         ".1x2",
 			expErrSubstr: "unexpected char",
 		},
 		{
-			desc:         "move 1::2 is invalid - no repeat separators",
-			path:         "1::2",
+			desc:         "move 1xx2 is invalid - no repeat separators",
+			path:         "1xx2",
 			expErrSubstr: "separator",
 		},
 		{
-			desc:         "move 1..2 is invalid - no repeat separators",
-			path:         "1..2",
+			desc:         "move 1--2 is invalid - no repeat separators",
+			path:         "1--2",
 			expErrSubstr: "separator",
 		},
 	}
@@ -127,7 +127,7 @@ func TestParsePath(t *testing.T) {
 				return
 			}
 
-			if !cmp.Equal(got, movetree.Treepath(tc.exp)) {
+			if !cmp.Equal(got, movetree.Path(tc.exp)) {
 				t.Errorf("ParsePath(%v)=%v, but expected %v", tc.path, got, tc.exp)
 			}
 		})
@@ -143,7 +143,7 @@ func TestApplyPath(t *testing.T) {
 	}{
 		{
 			desc: "first move",
-			path: ".0",
+			path: "-0",
 			game: "(;GM[1];PM[1]B[pd]C[foo])",
 			expProps: map[string][]string{
 				"C":  []string{"foo"},
@@ -176,7 +176,7 @@ func TestApplyPath(t *testing.T) {
 func TestString(t *testing.T) {
 	testCases := []struct {
 		desc string
-		tp   movetree.Treepath
+		tp   movetree.Path
 		exp  string
 	}{
 		{
@@ -208,33 +208,33 @@ func TestString(t *testing.T) {
 func TestCompactString(t *testing.T) {
 	testCases := []struct {
 		desc string
-		tp   movetree.Treepath
+		tp   movetree.Path
 		exp  string
 	}{
 		{
 			desc: "empty treepath",
 			tp:   []int{},
-			exp:  ".",
+			exp:  "-",
 		},
 		{
 			desc: "short treepath",
 			tp:   []int{1},
-			exp:  ".1",
+			exp:  "-1",
 		},
 		{
 			desc: "long repeat",
 			tp:   []int{1, 1, 1, 1},
-			exp:  ".1:4",
+			exp:  "-1x4",
 		},
 		{
 			desc: "long no repeat",
 			tp:   []int{1, 2, 3, 4, 5, 6},
-			exp:  ".1.2.3.4.5.6",
+			exp:  "-1-2-3-4-5-6",
 		},
 		{
 			desc: "long mixed",
 			tp:   []int{1, 2, 2, 0, 0, 5, 0, 2, 2, 2, 2, 1},
-			exp:  ".1.2:2.0:2.5.0.2:4.1",
+			exp:  "-1-2x2-0x2-5-0-2x4-1",
 		},
 	}
 	for _, tc := range testCases {

--- a/core/problems/problems.go
+++ b/core/problems/problems.go
@@ -8,10 +8,10 @@ import (
 	"github.com/otrego/clamshell/core/movetree"
 )
 
-// Flatten takes a Treepath and a MoveTree and returns
+// Flatten takes a Pathand a MoveTree and returns
 // the root of the flat movetree. the flat movetree
 // ignores the last two nodes of the treepath
-func Flatten(tp movetree.Treepath, g *movetree.MoveTree) (*movetree.MoveTree, error) {
+func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error) {
 	b, err := PopulateBoard(tp, g)
 	if err != nil {
 		return nil, err
@@ -28,10 +28,10 @@ func Flatten(tp movetree.Treepath, g *movetree.MoveTree) (*movetree.MoveTree, er
 
 }
 
-// PopulateBoard populates a go board given a MoveTree and Treepath
+// PopulateBoard populates a go board given a MoveTree and Path
 // Captures are intentionally discarded here.
 // returns the populated board.
-func PopulateBoard(tp movetree.Treepath, g *movetree.MoveTree) (*board.Board, error) {
+func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error) {
 	n := g.Root
 	i, err := strconv.Atoi(n.Properties["SZ"][0])
 	if err != nil {

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -34,7 +34,7 @@ func TestParse(t *testing.T) {
 			desc: "check parsing root: simple property",
 			sgf:  "(;GM[1])",
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"GM": []string{"1"},
 				},
 			},
@@ -43,7 +43,7 @@ func TestParse(t *testing.T) {
 			desc: "check parsing root: lots of whitespace",
 			sgf:  "\n   (;  C[1 \n1]   )",
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"C": []string{"1 \n1"},
 				},
 			},
@@ -52,12 +52,12 @@ func TestParse(t *testing.T) {
 			desc: "check parsing root: multi property",
 			sgf:  "(;GM[1]AW[ab][bc])",
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"GM": []string{"1"},
 				},
 			},
 			pathToNodeCheck: map[string]nodeCheck{
-				".": func(n *movetree.Node) error {
+				"-": func(n *movetree.Node) error {
 					expPlacements := []*move.Move{
 						move.NewMove(color.White, point.New(0, 1)),
 						move.NewMove(color.White, point.New(1, 2)),
@@ -73,7 +73,7 @@ func TestParse(t *testing.T) {
 			desc: "add new node",
 			sgf:  "(;GM[1];B[cc])",
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"GM": []string{"1"},
 				},
 			},
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 			desc: "comment with escaped rbrace",
 			sgf:  `(;C[aoeu [1k\]])`,
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"C": []string{"aoeu [1k]"},
 				},
 			},
@@ -100,7 +100,7 @@ func TestParse(t *testing.T) {
 			desc: "comment with non-escapng backslash",
 			sgf:  `(;C[aoeu \z])`,
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"C": []string{"aoeu \\z"},
 				},
 			},
@@ -109,7 +109,7 @@ func TestParse(t *testing.T) {
 			desc: "comment with lots of escaping",
 			sgf:  `(;C[\\\]])`,
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"C": []string{`\\]`},
 				},
 			},
@@ -118,14 +118,14 @@ func TestParse(t *testing.T) {
 			desc: "basic variation",
 			sgf:  `(;GM[1](;B[aa];W[ab])(;B[ab];W[ac]))`,
 			pathToNodeCheck: map[string]nodeCheck{
-				"0.0": func(n *movetree.Node) error {
+				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 1))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
-				"1.0": func(n *movetree.Node) error {
+				"1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
@@ -156,7 +156,7 @@ TR[sa][sb][sc]
 SQ[ra][rb][rc]
 )`,
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"GM": []string{"1"},
 					"SQ": []string{"ra", "rb", "rc"},
 					"PW": []string{"White"},
@@ -197,12 +197,12 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 (;B[]C[A default consideration]
 	;W[mc]C[White lives easily]))`,
 			pathToProps: map[string]propmap{
-				".": propmap{
+				"-": propmap{
 					"GM": []string{"1"},
 				},
 			},
 			pathToNodeCheck: map[string]nodeCheck{
-				"0.0": func(n *movetree.Node) error {
+				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
@@ -210,14 +210,14 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 					return nil
 				},
 				// should be same, since treepath terminates
-				"0.0.0": func(n *movetree.Node) error {
+				"0-0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
-				"1.1.0": func(n *movetree.Node) error {
+				"1-1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.Black, point.New(14, 0))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)

--- a/katalyze/processor.go
+++ b/katalyze/processor.go
@@ -24,14 +24,14 @@ type problemProcessor struct {
 
 type problem struct {
 	originalFile string
-	path         movetree.Treepath
+	path         movetree.Path
 	mt           *movetree.MoveTree
 	contents     string
 }
 
 func (p *problem) name() string {
 	return strings.TrimSuffix(p.originalFile, path.Ext(p.originalFile)) +
-		p.path.FileSafeCompactString() + ".sgf"
+		p.path.CompactString() + ".sgf"
 }
 
 // genProblems generates problems.
@@ -84,7 +84,7 @@ func (p *problemProcessor) processGame(fi string) ([]*problem, error) {
 	}
 	glog.Infof("Finished adding to game for file %q", fi)
 
-	var positions []movetree.Treepath
+	var positions []movetree.Path
 	paths, err := kataprob.FindBlunders(g)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR contains several cleanups for Treepath.

Rename movetree.Treepath => movetree.Path. This is a bit more idiomatic
because this reduces stutter -- 'tree' is already in the package name.

Also, change the separators for CompactString representation of

. => -
: => x

Example: 1.2.0:3 => 1-2-0x3

I think this reads slightly better (0x3 is very clear, in my mind) and
also can be used directly in filenames so no FileSafeCompactString is
necessary.