### PR TITLE
Add Properties Wrapper and Type-Size Property.

### DIFF
--- a/core/katago/query.go
+++ b/core/katago/query.go
@@ -132,7 +132,7 @@ func (gc *movetreeConverter) move(mv *move.Move) Move {
 // the initial stones for the analysis.
 func (gc *movetreeConverter) initialStones() []Move {
 	var out []Move
-	for _, mv := range gc.g.Root.Placements {
+	for _, mv := range gc.g.Root.Properties.Placements {
 		out = append(out, gc.move(mv))
 	}
 	return out
@@ -141,7 +141,7 @@ func (gc *movetreeConverter) initialStones() []Move {
 // initialPlayer sets the initial player. By default, katago assumes
 // black-to-play, so this isn't necessary.
 func (gc *movetreeConverter) initialPlayer() string {
-	if val, ok := gc.g.Root.Properties["PL"]; ok && len(val) > 0 {
+	if val, ok := gc.g.Root.SGFProperties["PL"]; ok && len(val) > 0 {
 		return val[0]
 	}
 	return ""
@@ -155,8 +155,8 @@ func (gc *movetreeConverter) mainBranchMoves(startFrom, maxMove int) []Move {
 		if maxMove > 0 && n.MoveNum() > (maxMove+startFrom-1) {
 			break
 		}
-		if n.Move != nil {
-			out = append(out, gc.move(n.Move))
+		if n.Properties.Move != nil {
+			out = append(out, gc.move(n.Properties.Move))
 		}
 		if len(n.Children) == 0 {
 			// No more children; terminate traversal.
@@ -169,7 +169,7 @@ func (gc *movetreeConverter) mainBranchMoves(startFrom, maxMove int) []Move {
 
 // rules gets the relevant rule-set, returning TrompTaylorRules if not provided.
 func (gc *movetreeConverter) rules() Rules {
-	if val, ok := gc.g.Root.Properties["RU"]; ok && len(val) > 0 {
+	if val, ok := gc.g.Root.SGFProperties["RU"]; ok && len(val) > 0 {
 		return Rules(val[0])
 	}
 	return TrompTaylorRules
@@ -178,7 +178,7 @@ func (gc *movetreeConverter) rules() Rules {
 // komi gets the komi value, parsed as a float. Note that the decimal-part can
 // only be exactl 0.5 or 0.
 func (gc *movetreeConverter) komi() (*float64, error) {
-	if val, ok := gc.g.Root.Properties["KM"]; ok && len(val) > 0 {
+	if val, ok := gc.g.Root.SGFProperties["KM"]; ok && len(val) > 0 {
 		km, err := strconv.ParseFloat(val[0], 64)
 		if err != nil {
 			return nil, err
@@ -195,17 +195,11 @@ func (gc *movetreeConverter) komi() (*float64, error) {
 // boardSize gets the size of the go board. Only sizes ups to 25 are allowed,
 // but should typically be 19, 13, or 9.
 func (gc *movetreeConverter) boardSize() (int, error) {
-	if val, ok := gc.g.Root.Properties["SZ"]; ok && len(val) > 0 {
-		sz, err := strconv.Atoi(val[0])
-		if err != nil {
-			return 0, err
-		}
-		if sz > 25 {
-			return 0, fmt.Errorf("only sizes up to 25 are supported")
-		}
-		return sz, nil
+	sz := gc.g.Root.Properties.Size
+	if sz == 0 {
+		sz = 19
 	}
-	return 19, nil
+	return sz, nil
 }
 
 // analyzeMainBranch analyzes the main branch of the movetree.

--- a/core/katago/query.go
+++ b/core/katago/query.go
@@ -132,7 +132,7 @@ func (gc *movetreeConverter) move(mv *move.Move) Move {
 // the initial stones for the analysis.
 func (gc *movetreeConverter) initialStones() []Move {
 	var out []Move
-	for _, mv := range gc.g.Root.Properties.Placements {
+	for _, mv := range gc.g.Root.Placements {
 		out = append(out, gc.move(mv))
 	}
 	return out
@@ -155,8 +155,8 @@ func (gc *movetreeConverter) mainBranchMoves(startFrom, maxMove int) []Move {
 		if maxMove > 0 && n.MoveNum() > (maxMove+startFrom-1) {
 			break
 		}
-		if n.Properties.Move != nil {
-			out = append(out, gc.move(n.Properties.Move))
+		if n.Move != nil {
+			out = append(out, gc.move(n.Move))
 		}
 		if len(n.Children) == 0 {
 			// No more children; terminate traversal.
@@ -195,7 +195,7 @@ func (gc *movetreeConverter) komi() (*float64, error) {
 // boardSize gets the size of the go board. Only sizes ups to 25 are allowed,
 // but should typically be 19, 13, or 9.
 func (gc *movetreeConverter) boardSize() (int, error) {
-	sz := gc.g.Root.Properties.Size
+	sz := gc.g.Root.GameInfo.Size
 	if sz == 0 {
 		sz = 19
 	}

--- a/core/movetree/game.go
+++ b/core/movetree/game.go
@@ -10,5 +10,9 @@ func New() *MoveTree {
 	g := &MoveTree{
 		Root: NewNode(),
 	}
+
+	// Sensible Defaults go here.
+	g.Root.Properties.Size = 19
+	g.Root.SGFProperties["GM"] = []string{"1"} // GM[1]=go
 	return g
 }

--- a/core/movetree/game.go
+++ b/core/movetree/game.go
@@ -11,8 +11,9 @@ func New() *MoveTree {
 		Root: NewNode(),
 	}
 
-	// Sensible Defaults go here.
-	g.Root.Properties.Size = 19
+	// sensible defaults go here.
+	g.Root.GameInfo = &GameInfo{}
+	g.Root.GameInfo.Size = 19
 	g.Root.SGFProperties["GM"] = []string{"1"} // GM[1]=go
 	return g
 }

--- a/core/movetree/node.go
+++ b/core/movetree/node.go
@@ -4,6 +4,22 @@ import (
 	"github.com/otrego/clamshell/core/move"
 )
 
+// Properties contains typed game properties that can exist on any node.
+type Properties struct {
+	// Placements are stones that are used for setup, but actual moves. For
+	// example, handicap stones will be in in placements.
+	Placements []*move.Move
+
+	// Move indicates a move in the game.
+	Move *move.Move
+
+	// Size of the board, where 19 = 19x19. Between 1 and 25 inclusive. A value of
+	// 0 should be taken to mean 'unspecified' and treated as 19x19.
+	//
+	// **RootProperty**
+	Size int
+}
+
 // Node contains Properties, Children nodes, and Parent node.
 type Node struct {
 	// moveNum is the move and indicates the current move number or depth for this
@@ -14,30 +30,28 @@ type Node struct {
 	// variation) should always be 0.
 	varNum int
 
-	// Placements are stones that are used for setup, but actual moves. For
-	// example, handicap stones will be in in placements.
-	Placements []*move.Move
-
-	// Move indicates a move in the game.
-	Move *move.Move
-
-	// Properties contain all the raw/unprocessed properties
-	Properties map[string][]string
-
 	// Children of this position.
 	Children []*Node
 
 	// Parent of this node.
 	Parent *Node
 
-	// analysisData contains arbitrary AnalysisData
+	// Properties contains properties found on any node.
+	Properties *Properties
+
+	// SGFProperties contain all the raw/unprocessed properties
+	SGFProperties map[string][]string
+
+	// analysisData contains arbitrary/untyped AnalysisData that is attached to
+	// this node.
 	analysisData interface{}
 }
 
 // NewNode creates a Node.
 func NewNode() *Node {
 	return &Node{
-		Properties: make(map[string][]string),
+		Properties:    &Properties{},
+		SGFProperties: make(map[string][]string),
 	}
 }
 

--- a/core/movetree/node.go
+++ b/core/movetree/node.go
@@ -4,19 +4,10 @@ import (
 	"github.com/otrego/clamshell/core/move"
 )
 
-// Properties contains typed game properties that can exist on any node.
-type Properties struct {
-	// Placements are stones that are used for setup, but actual moves. For
-	// example, handicap stones will be in in placements.
-	Placements []*move.Move
-
-	// Move indicates a move in the game.
-	Move *move.Move
-
+// GameInfo contains typed game properties that can exist only on the root.
+type GameInfo struct {
 	// Size of the board, where 19 = 19x19. Between 1 and 25 inclusive. A value of
 	// 0 should be taken to mean 'unspecified' and treated as 19x19.
-	//
-	// **RootProperty**
 	Size int
 }
 
@@ -36,8 +27,17 @@ type Node struct {
 	// Parent of this node.
 	Parent *Node
 
-	// Properties contains properties found on any node.
-	Properties *Properties
+	// Move indicates a move in the game. A move with a color + no intersection is
+	// used to indicate a pass.
+	Move *move.Move
+
+	// Placements are stones that are used for setup, but actual moves. For
+	// example, handicap stones will be in in placements.
+	Placements []*move.Move
+
+	// GameInfo contains properties only found on the root. Should be nil on
+	// non-root nodes.
+	GameInfo *GameInfo
 
 	// SGFProperties contain all the raw/unprocessed properties
 	SGFProperties map[string][]string
@@ -50,7 +50,6 @@ type Node struct {
 // NewNode creates a Node.
 func NewNode() *Node {
 	return &Node{
-		Properties:    &Properties{},
 		SGFProperties: make(map[string][]string),
 	}
 }

--- a/core/movetree/treepath_test.go
+++ b/core/movetree/treepath_test.go
@@ -166,7 +166,7 @@ func TestApplyPath(t *testing.T) {
 			}
 			n := path.Apply(g.Root)
 
-			if !cmp.Equal(n.Properties, tc.expProps) {
+			if !cmp.Equal(n.SGFProperties, tc.expProps) {
 				t.Errorf("path.Apply(root)=%v, expected %v. Diff=%v", n.Properties, tc.expProps, cmp.Diff(n.Properties, tc.expProps))
 			}
 		})

--- a/core/movetree/treepath_test.go
+++ b/core/movetree/treepath_test.go
@@ -167,7 +167,7 @@ func TestApplyPath(t *testing.T) {
 			n := path.Apply(g.Root)
 
 			if !cmp.Equal(n.SGFProperties, tc.expProps) {
-				t.Errorf("path.Apply(root)=%v, expected %v. Diff=%v", n.Properties, tc.expProps, cmp.Diff(n.Properties, tc.expProps))
+				t.Errorf("path.Apply(root)=%v, expected %v. Diff=%v", n.SGFProperties, tc.expProps, cmp.Diff(n.SGFProperties, tc.expProps))
 			}
 		})
 	}

--- a/core/problems/problems.go
+++ b/core/problems/problems.go
@@ -17,7 +17,7 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 	}
 
 	gflat := movetree.New()
-	gflat.Root.Properties.Placements = b.GetFullBoardState()
+	gflat.Root.Placements = b.GetFullBoardState()
 
 	for key, value := range g.Root.SGFProperties {
 		gflat.Root.SGFProperties[key] = value
@@ -31,10 +31,10 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 // returns the populated board.
 func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error) {
 	n := g.Root
-	i := n.Properties.Size
+	i := n.GameInfo.Size
 
 	b := board.NewBoard(i)
-	for _, move := range n.Properties.Placements {
+	for _, move := range n.Placements {
 		b.PlaceStone(move)
 	}
 
@@ -46,7 +46,7 @@ func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error)
 			return nil, fmt.Errorf("treepath leads to nil movetree node")
 		}
 
-		_, err := b.PlaceStone(n.Properties.Move)
+		_, err := b.PlaceStone(n.Move)
 		if err != nil {
 			return nil, err
 		}

--- a/core/problems/problems.go
+++ b/core/problems/problems.go
@@ -2,7 +2,6 @@ package problems
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/otrego/clamshell/core/board"
 	"github.com/otrego/clamshell/core/movetree"
@@ -18,14 +17,13 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 	}
 
 	gflat := movetree.New()
-	gflat.Root.Placements = b.GetFullBoardState()
+	gflat.Root.Properties.Placements = b.GetFullBoardState()
 
-	for key, value := range g.Root.Properties {
-		gflat.Root.Properties[key] = value
+	for key, value := range g.Root.SGFProperties {
+		gflat.Root.SGFProperties[key] = value
 	}
 
 	return gflat, nil
-
 }
 
 // PopulateBoard populates a go board given a MoveTree and Path
@@ -33,12 +31,10 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 // returns the populated board.
 func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error) {
 	n := g.Root
-	i, err := strconv.Atoi(n.Properties["SZ"][0])
-	if err != nil {
-		return nil, err
-	}
+	i := n.Properties.Size
+
 	b := board.NewBoard(i)
-	for _, move := range n.Placements {
+	for _, move := range n.Properties.Placements {
 		b.PlaceStone(move)
 	}
 
@@ -50,8 +46,8 @@ func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error)
 			return nil, fmt.Errorf("treepath leads to nil movetree node")
 		}
 
-		_, err2 := b.PlaceStone(n.Move)
-		if err2 != nil {
+		_, err := b.PlaceStone(n.Properties.Move)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/core/prop/converter_list_test.go
+++ b/core/prop/converter_list_test.go
@@ -29,7 +29,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewPass(color.Black)
+				n.Move = move.NewPass(color.Black)
 			},
 		},
 		{
@@ -37,7 +37,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{""},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewPass(color.Black)
+				n.Move = move.NewPass(color.Black)
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.NewMove(color.Black, point.New(0, 1))
 			},
 		},
 		{
@@ -53,7 +53,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "W",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Move = move.NewMove(color.White, point.New(0, 1))
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "AB",
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Placements = []*move.Move{
+				n.Placements = []*move.Move{
 					move.NewMove(color.Black, point.New(0, 0)),
 					move.NewMove(color.Black, point.New(1, 1)),
 				}
@@ -72,9 +72,19 @@ func TestConverters_From(t *testing.T) {
 			prop: "AW",
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Properties.Placements = []*move.Move{
+				n.Placements = []*move.Move{
 					move.NewMove(color.White, point.New(0, 0)),
 					move.NewMove(color.White, point.New(1, 1)),
+				}
+			},
+		},
+		{
+			desc: "size",
+			prop: "SZ",
+			data: []string{"13"},
+			makeExpNode: func(n *movetree.Node) {
+				n.GameInfo = &movetree.GameInfo{
+					Size: 13,
 				}
 			},
 		},
@@ -111,28 +121,28 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "black move: pass",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewPass(color.Black)
+				n.Move = move.NewPass(color.Black)
 			},
 			expOut: "B[]",
 		},
 		{
 			desc: "black move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.NewMove(color.Black, point.New(0, 1))
 			},
 			expOut: "B[ab]",
 		},
 		{
 			desc: "white move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Move = move.NewMove(color.White, point.New(0, 1))
 			},
 			expOut: "W[ab]",
 		},
 		{
 			desc: "black placements",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Placements = []*move.Move{
+				n.Placements = []*move.Move{
 					move.NewMove(color.Black, point.New(0, 1)),
 					move.NewMove(color.Black, point.New(0, 2)),
 				}
@@ -142,7 +152,7 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "white placements",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Placements = []*move.Move{
+				n.Placements = []*move.Move{
 					move.NewMove(color.White, point.New(0, 1)),
 					move.NewMove(color.White, point.New(0, 2)),
 				}
@@ -152,7 +162,7 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "black move, extra properties",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.NewMove(color.Black, point.New(0, 1))
 				n.SGFProperties["ZZ"] = []string{"zork"}
 			},
 			expOut: "B[ab]ZZ[zork]",
@@ -160,12 +170,37 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "extra properties, sorting",
 			makeNode: func(n *movetree.Node) {
-				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.NewMove(color.Black, point.New(0, 1))
 				n.SGFProperties["ZZ"] = []string{"zork"}
 				n.SGFProperties["AA"] = []string{"ark"}
 				n.SGFProperties["BB"] = []string{"bark"}
 			},
 			expOut: "B[ab]AA[ark]BB[bark]ZZ[zork]",
+		},
+		{
+			desc: "size",
+			makeNode: func(n *movetree.Node) {
+				n.GameInfo = &movetree.GameInfo{
+					Size: 13,
+				}
+			},
+			expOut: "SZ[13]",
+		},
+		{
+			desc: "size, empty",
+			makeNode: func(n *movetree.Node) {
+				n.GameInfo = &movetree.GameInfo{}
+			},
+			expOut: "",
+		},
+		{
+			desc: "size, invalid",
+			makeNode: func(n *movetree.Node) {
+				n.GameInfo = &movetree.GameInfo{
+					Size: 100,
+				}
+			},
+			expErrSubstr: "invalid board size",
 		},
 	}
 

--- a/core/prop/converter_list_test.go
+++ b/core/prop/converter_list_test.go
@@ -29,7 +29,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewPass(color.Black)
+				n.Properties.Move = move.NewPass(color.Black)
 			},
 		},
 		{
@@ -37,7 +37,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{""},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewPass(color.Black)
+				n.Properties.Move = move.NewPass(color.Black)
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "B",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
 			},
 		},
 		{
@@ -53,7 +53,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "W",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Properties.Move = move.NewMove(color.White, point.New(0, 1))
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "AB",
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Placements = []*move.Move{
+				n.Properties.Placements = []*move.Move{
 					move.NewMove(color.Black, point.New(0, 0)),
 					move.NewMove(color.Black, point.New(1, 1)),
 				}
@@ -72,7 +72,7 @@ func TestConverters_From(t *testing.T) {
 			prop: "AW",
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Placements = []*move.Move{
+				n.Properties.Placements = []*move.Move{
 					move.NewMove(color.White, point.New(0, 0)),
 					move.NewMove(color.White, point.New(1, 1)),
 				}
@@ -83,13 +83,9 @@ func TestConverters_From(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			n := movetree.NewNode()
-			conv := Converter(tc.prop)
-			if conv == nil {
-				t.Fatal("expected converter, but found none")
-			}
 			expNode := movetree.NewNode()
 			tc.makeExpNode(expNode)
-			err := conv.From(n, tc.prop, tc.data)
+			err := ProcessPropertyData(n, tc.prop, tc.data)
 			cerr := errcheck.CheckCases(err, tc.expErrSubstr)
 			if cerr != nil {
 				t.Fatal(cerr)
@@ -115,28 +111,28 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "black move: pass",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewPass(color.Black)
+				n.Properties.Move = move.NewPass(color.Black)
 			},
 			expOut: "B[]",
 		},
 		{
 			desc: "black move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
 			},
 			expOut: "B[ab]",
 		},
 		{
 			desc: "white move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Properties.Move = move.NewMove(color.White, point.New(0, 1))
 			},
 			expOut: "W[ab]",
 		},
 		{
 			desc: "black placements",
 			makeNode: func(n *movetree.Node) {
-				n.Placements = []*move.Move{
+				n.Properties.Placements = []*move.Move{
 					move.NewMove(color.Black, point.New(0, 1)),
 					move.NewMove(color.Black, point.New(0, 2)),
 				}
@@ -146,7 +142,7 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "white placements",
 			makeNode: func(n *movetree.Node) {
-				n.Placements = []*move.Move{
+				n.Properties.Placements = []*move.Move{
 					move.NewMove(color.White, point.New(0, 1)),
 					move.NewMove(color.White, point.New(0, 2)),
 				}
@@ -156,18 +152,18 @@ func TestConverters_ConvertNode(t *testing.T) {
 		{
 			desc: "black move, extra properties",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
-				n.Properties["ZZ"] = []string{"zork"}
+				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.SGFProperties["ZZ"] = []string{"zork"}
 			},
 			expOut: "B[ab]ZZ[zork]",
 		},
 		{
 			desc: "extra properties, sorting",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
-				n.Properties["ZZ"] = []string{"zork"}
-				n.Properties["AA"] = []string{"ark"}
-				n.Properties["BB"] = []string{"bark"}
+				n.Properties.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.SGFProperties["ZZ"] = []string{"zork"}
+				n.SGFProperties["AA"] = []string{"ark"}
+				n.SGFProperties["BB"] = []string{"bark"}
 			},
 			expOut: "B[ab]AA[ark]BB[bark]ZZ[zork]",
 		},

--- a/core/sgf/parser.go
+++ b/core/sgf/parser.go
@@ -87,7 +87,7 @@ type propBuffer struct {
 
 func (b *propBuffer) flush(n *movetree.Node) error {
 	if b.prop != "" && len(b.propdata) != 0 {
-		if err := postProcessProperties(n, b.prop, b.propdata); err != nil {
+		if err := prop.ProcessPropertyData(n, b.prop, b.propdata); err != nil {
 			return err
 		}
 	}
@@ -358,20 +358,5 @@ func handlePropData(stateData *stateData, pbuf *propBuffer) error {
 	// C[foo 1[k\] bar]
 	//    ^
 	stateData.addToBuf(stateData.curchar)
-	return nil
-}
-
-// postProcessProperties adds post-processing to properties, to allow for more
-// structure.
-func postProcessProperties(n *movetree.Node, p string, propData []string) error {
-	if !prop.HasConverter(p) {
-		// For properties without an explicit converter, add to unprocessed
-		// Properties.
-		n.Properties[p] = propData
-		return nil
-	}
-	if err := prop.Converter(p).From(n, p, propData); err != nil {
-		return err
-	}
 	return nil
 }

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -62,8 +62,8 @@ func TestParse(t *testing.T) {
 						move.NewMove(color.White, point.New(0, 1)),
 						move.NewMove(color.White, point.New(1, 2)),
 					}
-					if !reflect.DeepEqual(n.Properties.Placements, expPlacements) {
-						return fmt.Errorf("incorrect placements; got %v, but wanted %v", n.Properties.Placements, expPlacements)
+					if !reflect.DeepEqual(n.Placements, expPlacements) {
+						return fmt.Errorf("incorrect placements; got %v, but wanted %v", n.Placements, expPlacements)
 					}
 					return nil
 				},
@@ -80,8 +80,8 @@ func TestParse(t *testing.T) {
 			pathToNodeCheck: map[string]nodeCheck{
 				"0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.Black, point.New(2, 2))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
@@ -120,15 +120,15 @@ func TestParse(t *testing.T) {
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 1))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				"1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 2))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
@@ -165,8 +165,8 @@ SQ[ra][rb][rc]
 			pathToNodeCheck: map[string]nodeCheck{
 				"-": func(n *movetree.Node) error {
 					expSize := 19
-					if n.Properties.Size != expSize {
-						return fmt.Errorf("incorrect size; got %v, but wanted %v", n.Properties.Size, expSize)
+					if n.GameInfo.Size != expSize {
+						return fmt.Errorf("incorrect size; got %v, but wanted %v", n.GameInfo.Size, expSize)
 					}
 					return nil
 				},
@@ -212,30 +212,30 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				// should be same, since treepath terminates
 				"0-0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				"1-1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.Black, point.New(14, 0))
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				"3": func(n *movetree.Node) error {
 					expMove := move.NewPass(color.Black)
-					if !reflect.DeepEqual(n.Properties.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
+					if !reflect.DeepEqual(n.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
@@ -341,7 +341,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];B[ab])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Properties.Move
+				return n.Move
 			},
 			want: move.NewMove(color.Black, point.New(0, 1)),
 		},
@@ -350,7 +350,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];W[ab])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Properties.Move
+				return n.Move
 			},
 			want: move.NewMove(color.White, point.New(0, 1)),
 		},
@@ -359,7 +359,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];AB[ab][ac]AW[bb][bc])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Properties.Placements
+				return n.Placements
 			},
 			want: []*move.Move{
 				move.NewMove(color.Black, point.New(0, 1)),

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -62,8 +62,8 @@ func TestParse(t *testing.T) {
 						move.NewMove(color.White, point.New(0, 1)),
 						move.NewMove(color.White, point.New(1, 2)),
 					}
-					if !reflect.DeepEqual(n.Placements, expPlacements) {
-						return fmt.Errorf("incorrect placements; got %v, but wanted %v", n.Placements, expPlacements)
+					if !reflect.DeepEqual(n.Properties.Placements, expPlacements) {
+						return fmt.Errorf("incorrect placements; got %v, but wanted %v", n.Properties.Placements, expPlacements)
 					}
 					return nil
 				},
@@ -80,8 +80,8 @@ func TestParse(t *testing.T) {
 			pathToNodeCheck: map[string]nodeCheck{
 				"0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.Black, point.New(2, 2))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
@@ -120,15 +120,15 @@ func TestParse(t *testing.T) {
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 1))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
 				"1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(0, 2))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
@@ -160,7 +160,15 @@ SQ[ra][rb][rc]
 					"GM": []string{"1"},
 					"SQ": []string{"ra", "rb", "rc"},
 					"PW": []string{"White"},
-					"SZ": []string{"19"},
+				},
+			},
+			pathToNodeCheck: map[string]nodeCheck{
+				"-": func(n *movetree.Node) error {
+					expSize := 19
+					if n.Properties.Size != expSize {
+						return fmt.Errorf("incorrect size; got %v, but wanted %v", n.Properties.Size, expSize)
+					}
+					return nil
 				},
 			},
 		},
@@ -204,30 +212,30 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
 				// should be same, since treepath terminates
 				"0-0-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.White, point.New(13, 2))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
 				"1-1-0": func(n *movetree.Node) error {
 					expMove := move.NewMove(color.Black, point.New(14, 0))
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
 				"3": func(n *movetree.Node) error {
 					expMove := move.NewPass(color.Black)
-					if !reflect.DeepEqual(n.Move, expMove) {
-						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
+					if !reflect.DeepEqual(n.Properties.Move, expMove) {
+						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Properties.Move, expMove)
 					}
 					return nil
 				},
@@ -294,9 +302,9 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 				}
 				n := tp.Apply(g.Root)
 				for prop, expData := range pmap {
-					foundData, ok := n.Properties[prop]
+					foundData, ok := n.SGFProperties[prop]
 					if !ok {
-						t.Errorf("At path %q, properties did not contain expected property key %q. Properties were %v", path, prop, n.Properties)
+						t.Errorf("At path %q, properties did not contain expected property key %q. Properties were %v", path, prop, n.SGFProperties)
 					}
 					if !cmp.Equal(foundData, expData) {
 						t.Errorf("At path %q, property %q was %v, but expected %v", path, prop, foundData, expData)
@@ -333,7 +341,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];B[ab])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Move
+				return n.Properties.Move
 			},
 			want: move.NewMove(color.Black, point.New(0, 1)),
 		},
@@ -342,7 +350,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];W[ab])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Move
+				return n.Properties.Move
 			},
 			want: move.NewMove(color.White, point.New(0, 1)),
 		},
@@ -351,7 +359,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			sgf:  "(;GM[1];AB[ab][ac]AW[bb][bc])",
 			path: "0",
 			getter: func(n *movetree.Node) interface{} {
-				return n.Placements
+				return n.Properties.Placements
 			},
 			want: []*move.Move{
 				move.NewMove(color.Black, point.New(0, 1)),

--- a/core/sgf/serialize_test.go
+++ b/core/sgf/serialize_test.go
@@ -100,11 +100,11 @@ SQ[ra][rb][rc]
 			var sbWant strings.Builder
 			var sbGot strings.Builder
 			g.Root.Traverse(func(n *movetree.Node) {
-				sbWant.WriteString(fmt.Sprintf("%v", n.Properties))
+				sbWant.WriteString(fmt.Sprintf("%v", n.SGFProperties))
 			})
 
 			got.Root.Traverse(func(n *movetree.Node) {
-				sbGot.WriteString(fmt.Sprintf("%v", n.Properties))
+				sbGot.WriteString(fmt.Sprintf("%v", n.SGFProperties))
 			})
 
 			if sbWant.String() != sbGot.String() {

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrp
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.4.1 h1:7dLaJvASGRD7X49jSCSXXHwKPm0ZN9r9kJD+p+vS7dM=
 github.com/envoyproxy/protoc-gen-validate/tests v0.0.0-20200923200354-538267e6e8c9 h1:44u/vz5hPS1qIYfuiYYYWrEYrAlZvskKm3rl1Yp7Lcw=
+github.com/envoyproxy/protoc-gen-validate/tests v0.0.0-20201130035154-1bcea29601b5 h1:0tlKIS+hN2V/akGJ9OiQNiAP6dYYUlLNcHXO4hj5cu4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
@@ -490,6 +491,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -524,6 +526,7 @@ golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
More refactoring of Node Properties.

- Put all typed-properties inside a Properties wrapper.
- Add Size -- Fixes #86
- Add support for root-level properties
- Add sensible defaults to the Node object.
@Kashomon

(Depends on #165)