### PR TITLE
Clean up point

### DIFF
--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -68,7 +68,10 @@ func TestPointToSGFTranslate(t *testing.T) {
 
 	for _, tc := range testToSGFCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			toSGFOut, _ := New(tc.in.x, tc.in.y).ToSGF()
+			toSGFOut, err := New(tc.in.x, tc.in.y).ToSGF()
+			if err != nil {
+				t.Fatal(err)
+			}
 			if toSGFOut != tc.want {
 				t.Errorf("%q.ToSGF() = %q, but wanted %q", tc.in,
 					toSGFOut, tc.want)
@@ -119,7 +122,11 @@ func TestSGFToPointTranslate(t *testing.T) {
 
 	for _, tc := range testToPointCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			toPointOut, _ := NewFromSGF(tc.in)
+			toPointOut, err := NewFromSGF(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			// include the point.go *Point type X Y getters below
 			pointX := toPointOut.X()
 			pointY := toPointOut.Y()


### PR DESCRIPTION
This cleans up some lingering style issues with the point object.

- Use one map to generate the other, to ensure a bijection.
- Fail in the case of errors in unit tests.
- Clean up the SGF conversion to use more-idiomatic Go-style

Fixes: #93