### PR TITLE
Add bbox and refactor crop package

### DIFF
--- a/core/bbox/bbox.go
+++ b/core/bbox/bbox.go
@@ -1,0 +1,53 @@
+// Package bbox provides utilities for managing various types of bounding boxes.
+package bbox
+
+import (
+	"fmt"
+
+	"github.com/otrego/clamshell/core/point"
+)
+
+// New creates a new bounding box.
+func New(tl, br *point.Point) (*BoundingBox, error) {
+	if tl.X() >= br.X() || tl.Y() >= br.Y() {
+		// Open question: Should we allow 0-width / 0-height bboxes? It doesn't seem
+		// to have much practical value.
+		return nil, fmt.Errorf("bottom right must be greater than topleft "+
+			"but top left was %v and bottom right was %v", tl, br)
+	}
+	return &BoundingBox{
+		tl: tl,
+		br: br,
+	}, nil
+}
+
+// BoundingBox is a bounding box for a board, which provides a top-left and
+// bottom-right.
+type BoundingBox struct {
+	tl *point.Point
+	br *point.Point
+}
+
+// TopLeft point of the bounding box.
+func (b *BoundingBox) TopLeft() *point.Point { return b.tl }
+
+// BotRight point of the bounding box.
+func (b *BoundingBox) BotRight() *point.Point { return b.br }
+
+// Top side of the bounding box.
+func (b *BoundingBox) Top() int64 { return b.tl.Y() }
+
+// Left side of the bounding box
+func (b *BoundingBox) Left() int64 { return b.tl.X() }
+
+// Bottom side of the bounding box.
+func (b *BoundingBox) Bottom() int64 { return b.br.Y() }
+
+// Right side of the bounding box.
+func (b *BoundingBox) Right() int64 { return b.br.X() }
+
+// Width of the bounding box.
+func (b *BoundingBox) Width() int64 { return b.br.X() - b.tl.X() }
+
+// Height of the bounding box.
+func (b *BoundingBox) Height() int64 { return b.br.Y() - b.tl.Y() }

--- a/core/bbox/bbox.go
+++ b/core/bbox/bbox.go
@@ -10,8 +10,6 @@ import (
 // New creates a new bounding box.
 func New(tl, br *point.Point) (*BoundingBox, error) {
 	if tl.X() >= br.X() || tl.Y() >= br.Y() {
-		// Open question: Should we allow 0-width / 0-height bboxes? It doesn't seem
-		// to have much practical value.
 		return nil, fmt.Errorf("bottom right must be greater than topleft "+
 			"but top left was %v and bottom right was %v", tl, br)
 	}

--- a/core/bbox/bbox_test.go
+++ b/core/bbox/bbox_test.go
@@ -1,0 +1,60 @@
+package bbox
+
+import (
+	"testing"
+
+	"github.com/otrego/clamshell/core/point"
+)
+
+func TestBboxBasics(t *testing.T) {
+	tl := point.New(1, 2)
+	br := point.New(10, 13)
+
+	bbox, err := New(tl, br)
+	if err != nil {
+		t.Fatalf("error making bounding box: %v", err)
+	}
+
+	var exp int64
+	exp = 1
+	if got := bbox.TopLeft().X(); got != exp {
+		t.Errorf("bbox.TopLeft().X()=%d, but expected %d", got, exp)
+	}
+	if got := bbox.Left(); got != exp {
+		t.Errorf("bbox.Left()=%d, but expected %d", got, exp)
+	}
+
+	exp = 2
+	if got := bbox.TopLeft().Y(); got != exp {
+		t.Errorf("bbox.TopLeft().Y()=%d, but expected %d", got, exp)
+	}
+	if got := bbox.Top(); got != exp {
+		t.Errorf("bbox.Top()=%d, but expected %d", got, exp)
+	}
+
+	exp = 10
+	if got := bbox.BotRight().X(); got != exp {
+		t.Errorf("bbox.BotRight().X()=%d, but expected %d", got, exp)
+	}
+	if got := bbox.Right(); got != exp {
+		t.Errorf("bbox.Right()=%d, but expected %d", got, exp)
+	}
+
+	exp = 13
+	if got := bbox.BotRight().Y(); got != exp {
+		t.Errorf("bbox.BotRight().Y()=%d, but expected %d", got, exp)
+	}
+	if got := bbox.Bottom(); got != exp {
+		t.Errorf("bbox.Bottom()=%d, but expected %d", got, exp)
+	}
+
+	exp = 9
+	if got := bbox.Width(); got != exp {
+		t.Errorf("bbox.Width()=%d, but expected %d", got, exp)
+	}
+
+	exp = 11
+	if got := bbox.Height(); got != exp {
+		t.Errorf("bbox.Height()=%d, but expected %d", got, exp)
+	}
+}

--- a/core/crop/autocrop.go
+++ b/core/crop/autocrop.go
@@ -1,1 +1,0 @@
-package crop


### PR DESCRIPTION
This adds a new bounding box struct and refactors the crop package to
use the bounding box struct.

Fixes: #197