### PR TITLE
Convert point from int64 to int.

### DIFF
--- a/core/bbox/bbox.go
+++ b/core/bbox/bbox.go
@@ -33,19 +33,19 @@ func (b *BoundingBox) TopLeft() *point.Point { return b.tl }
 func (b *BoundingBox) BotRight() *point.Point { return b.br }
 
 // Top side of the bounding box.
-func (b *BoundingBox) Top() int64 { return b.tl.Y() }
+func (b *BoundingBox) Top() int { return b.tl.Y() }
 
 // Left side of the bounding box
-func (b *BoundingBox) Left() int64 { return b.tl.X() }
+func (b *BoundingBox) Left() int { return b.tl.X() }
 
 // Bottom side of the bounding box.
-func (b *BoundingBox) Bottom() int64 { return b.br.Y() }
+func (b *BoundingBox) Bottom() int { return b.br.Y() }
 
 // Right side of the bounding box.
-func (b *BoundingBox) Right() int64 { return b.br.X() }
+func (b *BoundingBox) Right() int { return b.br.X() }
 
 // Width of the bounding box.
-func (b *BoundingBox) Width() int64 { return b.br.X() - b.tl.X() }
+func (b *BoundingBox) Width() int { return b.br.X() - b.tl.X() }
 
 // Height of the bounding box.
-func (b *BoundingBox) Height() int64 { return b.br.Y() - b.tl.Y() }
+func (b *BoundingBox) Height() int { return b.br.Y() - b.tl.Y() }

--- a/core/bbox/bbox_test.go
+++ b/core/bbox/bbox_test.go
@@ -15,7 +15,7 @@ func TestBboxBasics(t *testing.T) {
 		t.Fatalf("error making bounding box: %v", err)
 	}
 
-	var exp int64
+	var exp int
 	exp = 1
 	if got := bbox.TopLeft().X(); got != exp {
 		t.Errorf("bbox.TopLeft().X()=%d, but expected %d", got, exp)

--- a/core/bbox/cropbox.go
+++ b/core/bbox/cropbox.go
@@ -13,7 +13,7 @@ type CropBox struct {
 }
 
 // CroppingPreset is a convenience enum for specifying a cropping direction.
-type CroppingPreset int64
+type CroppingPreset int
 
 const (
 	//TopLeft see below
@@ -69,10 +69,10 @@ const (
 //
 // Following the SGF covention, we consider the topleft to be 0,0
 func CropBoxFromPreset(p CroppingPreset, boardSize int) (*CropBox, error) {
-	bs := int64(boardSize)
+	bs := boardSize
 
 	halfInts := bs / 2
-	var minInts int64
+	var minInts int
 
 	top := minInts
 	left := minInts

--- a/core/board/board.go
+++ b/core/board/board.go
@@ -131,20 +131,20 @@ func (b *Board) capturedStones(pt *point.Point) []*point.Point {
 // inBounds returns true if x and y are in bounds
 // on the board, false otherwise.
 func (b *Board) inBounds(pt *point.Point) bool {
-	var x, y int = int(pt.X()), int(pt.Y())
+	var x, y int = pt.X(), pt.Y()
 	return x < len(b.board[0]) && y < len(b.board) &&
 		x >= 0 && y >= 0
 }
 
 // colorAt returns the color at point pt.
 func (b *Board) colorAt(pt *point.Point) color.Color {
-	var x, y int = int(pt.X()), int(pt.Y())
+	var x, y int = pt.X(), pt.Y()
 	return b.board[y][x]
 }
 
 // setColor sets the color m.Color at point m.Point.
 func (b *Board) setColor(m *move.Move) {
-	var x, y int = int(m.Point().X()), int(m.Point().Y())
+	var x, y int = m.Point().X(), m.Point().Y()
 	b.board[y][x] = m.Color()
 }
 
@@ -168,7 +168,7 @@ func (b *Board) GetFullBoardState() []*move.Move {
 		for j := 0; j < len(b.board[0]); j++ {
 			if b.board[i][j] != color.Empty {
 				moves = append(moves,
-					move.NewMove(b.board[i][j], point.New(int64(j), int64(i))))
+					move.NewMove(b.board[i][j], point.New(j, i)))
 			}
 		}
 	}

--- a/core/point/point.go
+++ b/core/point/point.go
@@ -8,12 +8,12 @@ import (
 // Point is a basic point. Although simple, the member variables are kept
 // private to ensure that Point remains immutable.
 type Point struct {
-	x int64
-	y int64
+	x int
+	y int
 }
 
 // New creates a new immutable Point.
-func New(x, y int64) *Point {
+func New(x, y int) *Point {
 	return &Point{
 		x: x,
 		y: y,
@@ -21,10 +21,10 @@ func New(x, y int64) *Point {
 }
 
 // X returns the x-value.
-func (pt *Point) X() int64 { return pt.x }
+func (pt *Point) X() int { return pt.x }
 
 // Y returns the y-value.
-func (pt *Point) Y() int64 { return pt.y }
+func (pt *Point) Y() int { return pt.y }
 
 // ToSGF converts a pointer-type (immutable) *Point
 // to an SGF Point (two letter string).
@@ -52,8 +52,8 @@ func (pt *Point) Key() Key {
 //
 //     Key{X:12, Y:15}
 type Key struct {
-	X int64
-	Y int64
+	X int
+	Y int
 }
 
 // Point converts a point-Key back to a point.

--- a/core/point/sgf.go
+++ b/core/point/sgf.go
@@ -4,9 +4,9 @@ import "fmt"
 
 // TODO(kashomon): This whole file needs to be moved to core/sgf
 
-// pointToSgfMap is a translation reference between int64 Point
+// pointToSgfMap is a translation reference between int Point
 // and string SGF-Point (rune) values
-var pointToSgfMap = map[int64]rune{
+var pointToSgfMap = map[int]rune{
 	0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g',
 	7: 'h', 8: 'i', 9: 'j', 10: 'k', 11: 'l', 12: 'm', 13: 'n',
 	14: 'o', 15: 'p', 16: 'q', 17: 'r', 18: 's', 19: 't', 20: 'u',
@@ -18,9 +18,9 @@ var pointToSgfMap = map[int64]rune{
 }
 
 // sgfToPointMap is a translation reference between string SGF-Point
-// (rune) values and int64 Point values
-var sgfToPointMap = func(m map[int64]rune) map[rune]int64 {
-	out := make(map[rune]int64)
+// (rune) values and int Point values
+var sgfToPointMap = func(m map[int]rune) map[rune]int {
+	out := make(map[rune]int)
 	for key, val := range m {
 		out[val] = key
 	}


### PR DESCRIPTION
Using int64 is a bit annoying because int and int64 don't easily convert
between eachother. Also, indices must be specified as integers, and
range also produces integers.