### PR TITLE
Add new move.List type + some helpers

### DIFF
--- a/core/board/board.go
+++ b/core/board/board.go
@@ -49,13 +49,13 @@ func (b *Board) PlaceStone(m *move.Move) ([]*point.Point, error) {
 	b.setColor(m)
 	capturedStones := b.findCapturedGroups(m)
 	if len(capturedStones) == 0 && len(b.capturedStones(m.Point())) != 0 {
-		b.setColor(move.NewMove(color.Empty, m.Point()))
+		b.setColor(move.New(color.Empty, m.Point()))
 		return nil, fmt.Errorf("move %v is suicidal", m.Point())
 	}
 	if len(capturedStones) == 1 {
 		b.ko = m.Point()
 		if ko != nil && *ko == *(capturedStones[0]) {
-			b.setColor(move.NewMove(color.Empty, m.Point()))
+			b.setColor(move.New(color.Empty, m.Point()))
 			return nil, fmt.Errorf("%v is an illegal ko move", m.Point())
 		}
 	}
@@ -82,7 +82,7 @@ func (b *Board) findCapturedGroups(m *move.Move) []*point.Point {
 // the board.
 func (b *Board) removeCapturedStones(capturedStones []*point.Point) {
 	for _, point := range capturedStones {
-		b.setColor(move.NewMove(color.Empty, point))
+		b.setColor(move.New(color.Empty, point))
 	}
 }
 
@@ -168,7 +168,7 @@ func (b *Board) GetFullBoardState() []*move.Move {
 		for j := 0; j < len(b.board[0]); j++ {
 			if b.board[i][j] != color.Empty {
 				moves = append(moves,
-					move.NewMove(b.board[i][j], point.New(j, i)))
+					move.New(b.board[i][j], point.New(j, i)))
 			}
 		}
 	}

--- a/core/board/board_test.go
+++ b/core/board/board_test.go
@@ -174,7 +174,7 @@ func TestRemoveCapturedStones(t *testing.T) {
 				{"", "", "", "", "B", "", "", "", ""}},
 				nil,
 			},
-			m: move.NewMove(color.Black, point.New(4, 4)),
+			m: move.New(color.Black, point.New(4, 4)),
 			exp: "[. . . . B . . . .]\n" +
 				"[. . . B . B . . .]\n" +
 				"[. . . B . B . . .]\n" +
@@ -209,7 +209,7 @@ func TestPlaceStone(t *testing.T) {
 		{
 			desc: "successful added stone",
 			b:    NewBoard(9),
-			m:    move.NewMove(color.Black, point.New(8, 8)),
+			m:    move.New(color.Black, point.New(8, 8)),
 			exp: "[. . . . . . . . .]\n" +
 				"[. . . . . . . . .]\n" +
 				"[. . . . . . . . .]\n" +
@@ -223,7 +223,7 @@ func TestPlaceStone(t *testing.T) {
 		{
 			desc: "successful added stone",
 			b:    NewBoard(9),
-			m:    move.NewMove(color.Black, point.New(0, 0)),
+			m:    move.New(color.Black, point.New(0, 0)),
 			exp: "[B . . . . . . . .]\n" +
 				"[. . . . . . . . .]\n" +
 				"[. . . . . . . . .]\n" +
@@ -247,7 +247,7 @@ func TestPlaceStone(t *testing.T) {
 				{"", "", "", "", "B", "", "", "", ""}},
 				nil,
 			},
-			m: move.NewMove(color.Black, point.New(4, 4)),
+			m: move.New(color.Black, point.New(4, 4)),
 			exp: "[. . . . B . . . .]\n" +
 				"[. . . B . B . . .]\n" +
 				"[. . . B . B . . .]\n" +
@@ -271,7 +271,7 @@ func TestPlaceStone(t *testing.T) {
 				{"", "", "", "", "", "", "", "", ""}},
 				nil,
 			},
-			m:            move.NewMove(color.White, point.New(33, 4)),
+			m:            move.New(color.White, point.New(33, 4)),
 			expErrSubstr: "out of bound",
 		},
 		{
@@ -287,7 +287,7 @@ func TestPlaceStone(t *testing.T) {
 				{"", "", "", "", "", "", "", "", ""}},
 				nil,
 			},
-			m:            move.NewMove(color.White, point.New(4, 3)),
+			m:            move.New(color.White, point.New(4, 3)),
 			expErrSubstr: "occupied",
 		},
 		{
@@ -303,7 +303,7 @@ func TestPlaceStone(t *testing.T) {
 				{"", "", "", "", "", "", "", "", ""}},
 				nil,
 			},
-			m:            move.NewMove(color.White, point.New(4, 4)),
+			m:            move.New(color.White, point.New(4, 4)),
 			expErrSubstr: "suicidal",
 		},
 		{
@@ -319,7 +319,7 @@ func TestPlaceStone(t *testing.T) {
 				{"", "", "", "", "", "", "", "", ""}},
 				point.New(4, 5),
 			},
-			m:            move.NewMove(color.White, point.New(4, 4)),
+			m:            move.New(color.White, point.New(4, 4)),
 			expErrSubstr: "illegal",
 		},
 	}

--- a/core/color/color.go
+++ b/core/color/color.go
@@ -29,6 +29,21 @@ func (c Color) Opposite() Color {
 	return c
 }
 
+// Ordinal returns an ordinal number for the color, for the purposes of sorting.
+func (c Color) Ordinal() int {
+	switch c {
+	case Black:
+		return 1
+	case White:
+		return 2
+	case Empty:
+		return 3
+	default:
+		// This shouldn't happen normally, but here for good measure.
+		return 4
+	}
+}
+
 // ErrColorConversion is an err
 var ErrColorConversion = errors.New("color conversion error")
 

--- a/core/move/move.go
+++ b/core/move/move.go
@@ -14,8 +14,8 @@ type Move struct {
 	point *point.Point
 }
 
-// NewMove creates a new Move.
-func NewMove(col color.Color, pt *point.Point) *Move {
+// New creates a new Move.
+func New(col color.Color, pt *point.Point) *Move {
 	return &Move{color: col, point: pt}
 }
 
@@ -34,9 +34,14 @@ func (m *Move) Point() *point.Point {
 	return m.point
 }
 
-// String returns the string value for a Move
+// String returns the string value for a Move.
 func (m *Move) String() string {
 	return fmt.Sprintf("{%v, %v}", m.color, m.point)
+}
+
+// GoString returns the string value.
+func (m *Move) GoString() string {
+	return fmt.Sprintf("{Color:%v, Point:%v}", m.color, m.point)
 }
 
 // IsPass indicates whether this is a 'pass' move (i.e., there is a player but

--- a/core/move/move_list.go
+++ b/core/move/move_list.go
@@ -1,0 +1,43 @@
+package move
+
+import (
+	"sort"
+	"strings"
+)
+
+// List is a convenience helper for a list of moves.
+type List []*Move
+
+// Sort the list of moves (in-place), in order to have a well-ordered
+// collection of moves.
+//
+// The rules:
+// - Black moves are sorted before White and then Empty (although we don't
+//   generally allow empty moves.
+// - X values are compared next
+// - Y values are compared last
+func (m List) Sort() {
+	sort.Slice(m, func(i, j int) bool {
+		if m[i].Color() != m[j].Color() {
+			return m[i].Color().Ordinal() < m[j].Color().Ordinal()
+		}
+		if m[i].Point().X() != m[j].Point().X() {
+			return m[i].Point().X() < m[j].Point().X()
+		}
+		return m[i].Point().Y() < m[j].Point().Y()
+	})
+}
+
+// String returns the string for of the List.
+func (m List) String() string {
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i, mv := range m {
+		sb.WriteString(mv.String())
+		if i < len(m)-1 {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteString("}")
+	return sb.String()
+}

--- a/core/move/move_list_test.go
+++ b/core/move/move_list_test.go
@@ -1,0 +1,43 @@
+package move
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/otrego/clamshell/core/color"
+	"github.com/otrego/clamshell/core/point"
+)
+
+func TestMoveList_String(t *testing.T) {
+	mvStr := List{
+		New(color.Black, point.New(1, 2)),
+		New(color.White, point.New(3, 4)),
+	}.String()
+
+	exp := "{{B, {1,2}}, {W, {3,4}}}"
+	if mvStr != exp {
+		t.Errorf("mvlist.String()=%s, but expected %s. diff=%s", mvStr, exp, cmp.Diff(mvStr, exp))
+	}
+}
+
+func TestMoveList_Sort(t *testing.T) {
+	mv := List{
+		New(color.Black, point.New(1, 2)),
+		New(color.White, point.New(3, 4)),
+		New(color.Black, point.New(2, 2)),
+		New(color.White, point.New(2, 2)),
+	}
+	exp := List{
+		New(color.Black, point.New(1, 2)),
+		New(color.Black, point.New(2, 2)),
+		New(color.White, point.New(2, 2)),
+		New(color.White, point.New(3, 4)),
+	}
+
+	mv.Sort()
+	if !reflect.DeepEqual(mv, exp) {
+		t.Errorf("after sorting got %v, but expected %v. diff=%v", mv, exp,
+			cmp.Diff(mv.String(), exp.String()))
+	}
+}

--- a/core/move/move_test.go
+++ b/core/move/move_test.go
@@ -20,7 +20,7 @@ func TestFromSGFPoint(t *testing.T) {
 			desc:  "Valid Placement",
 			sgfPt: "ab",
 			col:   color.Black,
-			exp:   NewMove(color.Black, point.New(0, 1)),
+			exp:   New(color.Black, point.New(0, 1)),
 		},
 		{
 			desc:  "Pass",
@@ -32,7 +32,7 @@ func TestFromSGFPoint(t *testing.T) {
 			desc:  "Valid Placement White",
 			sgfPt: "ab",
 			col:   color.White,
-			exp:   NewMove(color.White, point.New(0, 1)),
+			exp:   New(color.White, point.New(0, 1)),
 		},
 		{
 			desc:  "Pass White",
@@ -110,13 +110,13 @@ func TestListFromSGFPoints(t *testing.T) {
 			desc:      "Valid List",
 			sgfPtList: []string{"ab", "cd", "ee"},
 			col:       color.Black,
-			exp:       []*Move{NewMove(color.Black, point.New(0, 1)), NewMove(color.Black, point.New(2, 3)), NewMove(color.Black, point.New(4, 4))},
+			exp:       []*Move{New(color.Black, point.New(0, 1)), New(color.Black, point.New(2, 3)), New(color.Black, point.New(4, 4))},
 		},
 		{
 			desc:      "Valid List White",
 			sgfPtList: []string{"ab", "cd", "ee"},
 			col:       color.White,
-			exp:       []*Move{NewMove(color.White, point.New(0, 1)), NewMove(color.White, point.New(2, 3)), NewMove(color.White, point.New(4, 4))},
+			exp:       []*Move{New(color.White, point.New(0, 1)), New(color.White, point.New(2, 3)), New(color.White, point.New(4, 4))},
 		},
 		{
 			desc:      "Empty Move List",

--- a/core/prop/converter_list_test.go
+++ b/core/prop/converter_list_test.go
@@ -97,7 +97,7 @@ func TestConvertNode_Collection(t *testing.T) {
 		{
 			desc: "black move, extra properties",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.New(color.Black, point.New(0, 1))
 				n.SGFProperties["ZZ"] = []string{"zork"}
 			},
 			expOut: "B[ab]ZZ[zork]",
@@ -105,7 +105,7 @@ func TestConvertNode_Collection(t *testing.T) {
 		{
 			desc: "extra properties, sorting",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.New(color.Black, point.New(0, 1))
 				n.SGFProperties["ZZ"] = []string{"zork"}
 				n.SGFProperties["AA"] = []string{"ark"}
 				n.SGFProperties["BB"] = []string{"bark"}

--- a/core/prop/moves_test.go
+++ b/core/prop/moves_test.go
@@ -32,7 +32,7 @@ func TestConvertFromSGF_Moves(t *testing.T) {
 			prop: "B",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.New(color.Black, point.New(0, 1))
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestConvertFromSGF_Moves(t *testing.T) {
 			prop: "W",
 			data: []string{"ab"},
 			makeExpNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Move = move.New(color.White, point.New(0, 1))
 			},
 		},
 	}
@@ -60,14 +60,14 @@ func TestConvertNode_Moves(t *testing.T) {
 		{
 			desc: "black move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.Black, point.New(0, 1))
+				n.Move = move.New(color.Black, point.New(0, 1))
 			},
 			expOut: "B[ab]",
 		},
 		{
 			desc: "white move: non-pass",
 			makeNode: func(n *movetree.Node) {
-				n.Move = move.NewMove(color.White, point.New(0, 1))
+				n.Move = move.New(color.White, point.New(0, 1))
 			},
 			expOut: "W[ab]",
 		},

--- a/core/prop/placements_test.go
+++ b/core/prop/placements_test.go
@@ -17,8 +17,8 @@ func TestConvertFromSGF_Placements(t *testing.T) {
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
 				n.Placements = []*move.Move{
-					move.NewMove(color.Black, point.New(0, 0)),
-					move.NewMove(color.Black, point.New(1, 1)),
+					move.New(color.Black, point.New(0, 0)),
+					move.New(color.Black, point.New(1, 1)),
 				}
 			},
 		},
@@ -28,8 +28,8 @@ func TestConvertFromSGF_Placements(t *testing.T) {
 			data: []string{"aa", "bb"},
 			makeExpNode: func(n *movetree.Node) {
 				n.Placements = []*move.Move{
-					move.NewMove(color.White, point.New(0, 0)),
-					move.NewMove(color.White, point.New(1, 1)),
+					move.New(color.White, point.New(0, 0)),
+					move.New(color.White, point.New(1, 1)),
 				}
 			},
 		},
@@ -44,8 +44,8 @@ func TestConvertNode_Placements(t *testing.T) {
 			desc: "black placements",
 			makeNode: func(n *movetree.Node) {
 				n.Placements = []*move.Move{
-					move.NewMove(color.Black, point.New(0, 1)),
-					move.NewMove(color.Black, point.New(0, 2)),
+					move.New(color.Black, point.New(0, 1)),
+					move.New(color.Black, point.New(0, 2)),
 				}
 			},
 			expOut: "AB[ab][ac]",
@@ -54,8 +54,8 @@ func TestConvertNode_Placements(t *testing.T) {
 			desc: "white placements",
 			makeNode: func(n *movetree.Node) {
 				n.Placements = []*move.Move{
-					move.NewMove(color.White, point.New(0, 1)),
-					move.NewMove(color.White, point.New(0, 2)),
+					move.New(color.White, point.New(0, 1)),
+					move.New(color.White, point.New(0, 2)),
 				}
 			},
 			expOut: "AW[ab][ac]",

--- a/core/sgf/parser_test.go
+++ b/core/sgf/parser_test.go
@@ -59,8 +59,8 @@ func TestParse(t *testing.T) {
 			pathToNodeCheck: map[string]nodeCheck{
 				"-": func(n *movetree.Node) error {
 					expPlacements := []*move.Move{
-						move.NewMove(color.White, point.New(0, 1)),
-						move.NewMove(color.White, point.New(1, 2)),
+						move.New(color.White, point.New(0, 1)),
+						move.New(color.White, point.New(1, 2)),
 					}
 					if !reflect.DeepEqual(n.Placements, expPlacements) {
 						return fmt.Errorf("incorrect placements; got %v, but wanted %v", n.Placements, expPlacements)
@@ -79,7 +79,7 @@ func TestParse(t *testing.T) {
 			},
 			pathToNodeCheck: map[string]nodeCheck{
 				"0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.Black, point.New(2, 2))
+					expMove := move.New(color.Black, point.New(2, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
@@ -119,14 +119,14 @@ func TestParse(t *testing.T) {
 			sgf:  `(;GM[1](;B[aa];W[ab])(;B[ab];W[ac]))`,
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.White, point.New(0, 1))
+					expMove := move.New(color.White, point.New(0, 1))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				"1-0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.White, point.New(0, 2))
+					expMove := move.New(color.White, point.New(0, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
@@ -211,7 +211,7 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 			},
 			pathToNodeCheck: map[string]nodeCheck{
 				"0-0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.White, point.New(13, 2))
+					expMove := move.New(color.White, point.New(13, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
@@ -219,14 +219,14 @@ AB[na][ra][mb][rb][lc][qc][ld][od][qd][le][pe][qe][mf][nf][of][pg]
 				},
 				// should be same, since treepath terminates
 				"0-0-0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.White, point.New(13, 2))
+					expMove := move.New(color.White, point.New(13, 2))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
 					return nil
 				},
 				"1-1-0": func(n *movetree.Node) error {
-					expMove := move.NewMove(color.Black, point.New(14, 0))
+					expMove := move.New(color.Black, point.New(14, 0))
 					if !reflect.DeepEqual(n.Move, expMove) {
 						return fmt.Errorf("incorrect move; got %v, but wanted %v", n.Move, expMove)
 					}
@@ -343,7 +343,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			getter: func(n *movetree.Node) interface{} {
 				return n.Move
 			},
-			want: move.NewMove(color.Black, point.New(0, 1)),
+			want: move.New(color.Black, point.New(0, 1)),
 		},
 		{
 			desc: "white move",
@@ -352,7 +352,7 @@ func TestPropertyPostProcessing(t *testing.T) {
 			getter: func(n *movetree.Node) interface{} {
 				return n.Move
 			},
-			want: move.NewMove(color.White, point.New(0, 1)),
+			want: move.New(color.White, point.New(0, 1)),
 		},
 		{
 			desc: "black & white placements",
@@ -362,10 +362,10 @@ func TestPropertyPostProcessing(t *testing.T) {
 				return n.Placements
 			},
 			want: []*move.Move{
-				move.NewMove(color.Black, point.New(0, 1)),
-				move.NewMove(color.Black, point.New(0, 2)),
-				move.NewMove(color.White, point.New(1, 1)),
-				move.NewMove(color.White, point.New(1, 2)),
+				move.New(color.Black, point.New(0, 1)),
+				move.New(color.Black, point.New(0, 2)),
+				move.New(color.White, point.New(1, 1)),
+				move.New(color.White, point.New(1, 2)),
 			},
 		},
 	}


### PR DESCRIPTION

- This PR adds a help some helpers to move.go, move_list.go.
- Also renames move.NewMove to move.New for concise-ness.
- Additionally, this adds a move.List type, with some useful properties
  (sorting, string)
