### PR TITLE
Fix equal method on point

### DIFF
--- a/core/point/point.go
+++ b/core/point/point.go
@@ -32,9 +32,9 @@ func (pt *Point) ToSGF() (string, error) {
 	return toSGF(pt)
 }
 
-// Equals returns whether this point is equal to another point.
-func (pt *Point) Equals(other *Point) bool {
-	return pt.X() == other.X() && pt.Y() == other.Y()
+// Equal returns whether this point is equal to another point.
+func (pt *Point) Equal(other *Point) bool {
+	return other != nil && pt.X() == other.X() && pt.Y() == other.Y()
 }
 
 // String converts to string representation of a Point.

--- a/core/point/point_test.go
+++ b/core/point/point_test.go
@@ -153,7 +153,7 @@ func TestKey(t *testing.T) {
 	}
 
 	back := exp.Point()
-	if !pt.Equals(back) {
+	if !pt.Equal(back) {
 		t.Errorf("error converting key to point: got %v, but expected %v", back, pt)
 	}
 }


### PR DESCRIPTION
This method renames Equals to Equal, which is the standard naming.

Fixes: https://github.com/otrego/clamshell/issues/225