### PR TITLE
Add more board helpers in prep for adding snapshot support

### DIFF
--- a/core/board/board.go
+++ b/core/board/board.go
@@ -173,10 +173,14 @@ func (b *Board) SetPlacements(ml move.List) error {
 	for _, m := range ml {
 		b.setColor(m)
 	}
-
 	// TODO(kashomon): Validate we have a valid board position -- i.e., one
 	// without captures lying on the board.
 	return nil
+}
+
+// Ko returns the ko point.
+func (b *Board) Ko() *point.Point {
+	return b.ko
 }
 
 // Clone makes a board copy.
@@ -195,10 +199,9 @@ func (b *Board) Clone() *Board {
 	return newb
 }
 
-// GetFullBoardState returns an array of all the current stone positions.
-func (b *Board) GetFullBoardState() []*move.Move {
-	moves := make([]*move.Move, 0)
-
+// StoneState returns an array of all the current stone positions.
+func (b *Board) StoneState() move.List {
+	var moves move.List
 	for i := 0; i < len(b.board); i++ {
 		for j := 0; j < len(b.board[0]); j++ {
 			if b.board[i][j] != color.Empty {
@@ -207,8 +210,19 @@ func (b *Board) GetFullBoardState() []*move.Move {
 			}
 		}
 	}
-
 	return moves
+}
+
+// FullBoardState returns the full board state.
+func (b *Board) FullBoardState() [][]color.Color {
+	out := make([][]color.Color, len(b.board))
+	for i, row := range b.board {
+		out[i] = make([]color.Color, len(row))
+		for j, col := range row {
+			out[i][j] = col
+		}
+	}
+	return out
 }
 
 // String returns a string representation of this board.

--- a/core/board/board_test.go
+++ b/core/board/board_test.go
@@ -417,3 +417,49 @@ func TestClone(t *testing.T) {
 		t.Fatalf("b.Clone()=%v, but expected %v. diff=%v", b.String(), newb.String(), cmp.Diff(b.String(), newb.String()))
 	}
 }
+
+func TestStoneState(t *testing.T) {
+	b := New(5)
+	err := b.SetPlacements(move.List{
+		move.New(color.Black, point.New(2, 3)),
+		move.New(color.White, point.New(2, 4)),
+		move.New(color.White, point.New(1, 1)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fbstate := b.StoneState()
+	expState := move.List{
+		move.New(color.White, point.New(1, 1)),
+		move.New(color.Black, point.New(2, 3)),
+		move.New(color.White, point.New(2, 4)),
+	}
+	if !reflect.DeepEqual(fbstate, expState) {
+		t.Errorf("got stone state %v, but expected %v", fbstate, expState)
+	}
+}
+
+func TestFullBoardState(t *testing.T) {
+	b := New(5)
+	err := b.SetPlacements(move.List{
+		move.New(color.Black, point.New(2, 3)),
+		move.New(color.White, point.New(2, 4)),
+		move.New(color.White, point.New(1, 1)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fbstate := b.FullBoardState()
+	expState := [][]color.Color{
+		[]color.Color{color.Empty, color.Empty, color.Empty, color.Empty, color.Empty},
+		[]color.Color{color.Empty, color.White, color.Empty, color.Empty, color.Empty},
+		[]color.Color{color.Empty, color.Empty, color.Empty, color.Empty, color.Empty},
+		[]color.Color{color.Empty, color.Empty, color.Black, color.Empty, color.Empty},
+		[]color.Color{color.Empty, color.Empty, color.White, color.Empty, color.Empty},
+	}
+	if !cmp.Equal(fbstate, expState) {
+		t.Errorf("got full stone state %v, but expected %v. diff=%v", fbstate, expState, cmp.Diff(fbstate, expState))
+	}
+}

--- a/core/movetree/movetree.go
+++ b/core/movetree/movetree.go
@@ -16,8 +16,8 @@ func New() *MoveTree {
 	// sensible defaults go here.
 	g.Root.GameInfo = &GameInfo{}
 	g.Root.GameInfo.Size = 19
-	g.Root.SGFProperties["GM"] = []string{"1"} 		// GM[1]=go
-	g.Root.SGFProperties["FF"] = []string{"4"} 		// FF[4]=SGF file format 4
-	g.Root.SGFProperties["CA"] = []string{"UTF-8"}	// CA[UTF-8]=UTF-8 encoding 
+	g.Root.SGFProperties["GM"] = []string{"1"}     // GM[1]=go
+	g.Root.SGFProperties["FF"] = []string{"4"}     // FF[4]=SGF file format 4
+	g.Root.SGFProperties["CA"] = []string{"UTF-8"} // CA[UTF-8]=UTF-8 encoding
 	return g
 }

--- a/core/problems/problems.go
+++ b/core/problems/problems.go
@@ -7,9 +7,8 @@ import (
 	"github.com/otrego/clamshell/core/movetree"
 )
 
-// Flatten takes a Pathand a MoveTree and returns
-// the root of the flat movetree. the flat movetree
-// ignores the last two nodes of the treepath
+// Flatten takes a Path and a MoveTree and returns the root of the flat
+// movetree. The flat movetree ignores the last two nodes of the treepath.
 func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error) {
 	b, err := PopulateBoard(tp, g)
 	if err != nil {
@@ -17,7 +16,7 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 	}
 
 	gflat := movetree.New()
-	gflat.Root.Placements = b.GetFullBoardState()
+	gflat.Root.Placements = b.StoneState()
 	gflat.Root.GameInfo.Size = g.Root.GameInfo.Size
 
 	for key, value := range g.Root.SGFProperties {
@@ -27,9 +26,8 @@ func Flatten(tp movetree.Path, g *movetree.MoveTree) (*movetree.MoveTree, error)
 	return gflat, nil
 }
 
-// PopulateBoard populates a go board given a MoveTree and Path
-// Captures are intentionally discarded here.
-// returns the populated board.
+// PopulateBoard populates a go board given a MoveTree and Path. Captures are
+// intentionally discarded here. Returns the populated board.
 func PopulateBoard(tp movetree.Path, g *movetree.MoveTree) (*board.Board, error) {
 	n := g.Root
 	i := n.GameInfo.Size

--- a/core/snapshot/board.go
+++ b/core/snapshot/board.go
@@ -1,0 +1,22 @@
+package snapshot
+
+import (
+	"github.com/otrego/clamshell/core/bbox"
+	"github.com/otrego/clamshell/core/board"
+)
+
+// createBoard creates a Board snapshot from some board state
+func createBoard(b *board.Board) (*Board, error) {
+	// TODO(kashomon): Add support for this
+	return nil, nil
+}
+
+// Board is a snapshot-board representation. It can be cropped.
+type Board struct {
+	// Intersections contain the intersections for the board.
+	Intersections [][]*Intersection
+
+	// The CropBox for the board, specifying the original size and the cropped
+	// bounding box.
+	CropBox *bbox.CropBox
+}

--- a/core/snapshot/snapshot.go
+++ b/core/snapshot/snapshot.go
@@ -6,7 +6,7 @@
 package snapshot
 
 import (
-	"github.com/otrego/clamshell/core/bbox"
+	"github.com/otrego/clamshell/core/board"
 	"github.com/otrego/clamshell/core/movetree"
 )
 
@@ -15,9 +15,16 @@ type Options struct {
 }
 
 // Create a new Snapshot from a given movetree and path.
-func Create(mt *movetree.MoveTree, pos movetree.Path, opts *Options) *Snapshot {
-
-	return &Snapshot{}
+func Create(mt *movetree.MoveTree, pos movetree.Path, opts *Options) (*Snapshot, error) {
+	size := mt.Root.GameInfo.Size
+	n := pos.Apply(mt.Root)
+	_, _, err := pos.ApplyToBoard(mt.Root, board.New(size))
+	if err != nil {
+		return nil, err
+	}
+	return &Snapshot{
+		Comment: n.Comment,
+	}, nil
 }
 
 // A Snapshot represents a specific board position, which can be used during
@@ -28,14 +35,4 @@ type Snapshot struct {
 
 	// Borad contains the symbolic representation of the display of the board.
 	Board *Board
-}
-
-// Board is a snapshot-board representation. It can be cropped.
-type Board struct {
-	// Intersections contain the intersections for the board.
-	Intersections [][]*Intersection
-
-	// The CropBox for the board, specifying the original size and the cropped
-	// bounding box.
-	CropBox *bbox.CropBox
 }

--- a/core/snapshot/snapshot.go
+++ b/core/snapshot/snapshot.go
@@ -15,7 +15,8 @@ type Options struct {
 }
 
 // Create a new Snapshot from a given movetree and path.
-func Create(mt *movetree.MoveTree, position movetree.Path, opts *Options) *Snapshot {
+func Create(mt *movetree.MoveTree, pos movetree.Path, opts *Options) *Snapshot {
+
 	return &Snapshot{}
 }
 


### PR DESCRIPTION
Add more board helpers in prep for adding snapshot support

- Ko method
- StoneState => returns moveList
- FullBoardState => returns a board copy.
- Slightly more sketching of the board-snapshot